### PR TITLE
(MODULES-3049) Add type and provider for IIS sites

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,0 +1,21 @@
+Facter.add("iis_version") do
+ confine :kernel => :windows
+  setcode do
+    begin
+      require 'win32/registry'
+      ACCESS_TYPE = Win32::Registry::KEY_READ | 0x100
+      HKLM        = Win32::Registry::HKEY_LOCAL_MACHINE
+      REG_PATH    = 'SOFTWARE\Microsoft\InetStp'
+      REG_KEY     = 'VersionString'
+      
+      iis_ver = nil
+      HKLM.open(REG_PATH, ACCESS_TYPE) do |reg|
+        iis_ver = reg[REG_KEY]
+      end
+      iis_ver = iis_ver[8,3]
+    rescue
+      iis_ver = ""
+    end
+    iis_ver
+  end
+end

--- a/lib/puppet/provider/iis_site/iisadministration.rb
+++ b/lib/puppet/provider/iis_site/iisadministration.rb
@@ -1,0 +1,23 @@
+require 'pathname'
+
+Puppet::Type.type(:iis_site).provide(:iisadministration) do
+  desc "IIS Provider using the PowerShell IISAdministration module"
+  
+  require_relative File.join(File.dirname(__FILE__), '../../../puppet_x/puppetlabs/iis/powershell_manager')
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/puppetlabs/iis/powershell_common'
+  include PuppetX::IIS::PowerShellCommon
+  
+  confine    :iis_version      => ['10']
+  confine    :operatingsystem  => [:windows ]
+  confine    :kernelmajversion => 10.0
+  defaultfor :operatingsystem  => :windows
+
+  commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path
+
+  mk_resource_methods
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+end

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -1,0 +1,175 @@
+require 'pathname'
+
+# When writing IIS PowerShell code for any of the methods below
+# NEVER EVER use Get-Website without specifying -Name. As the number
+# of sites on a server increases, Get-Website will take longer and longer
+# to return. This will exponentially increase the total duration of your
+# puppet run
+
+Puppet::Type.type(:iis_site).provide(:webadministration) do
+  desc "IIS Provider using the PowerShell WebAdministration module"
+
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/puppetlabs/iis/powershell_manager'
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/puppetlabs/iis/powershell_common'
+  include PuppetX::IIS::PowerShellCommon
+  
+  confine    :iis_version     => ['8','8.5']
+  confine    :operatingsystem => [:windows ]
+  defaultfor :operatingsystem => :windows
+
+  commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path
+
+  mk_resource_methods
+
+  def create
+    cmd = []
+
+    cmd << self.class.ps_script_content('_newwebsite', @resource)
+
+    cmd << self.class.ps_script_content('generalproperties', @resource)
+
+    cmd << self.class.ps_script_content('logproperties', @resource)
+
+    cmd << self.class.ps_script_content('serviceautostartprovider', @resource)
+
+    inst_cmd = cmd.join
+
+    result = self.class.run(inst_cmd)
+
+    Puppet.err "Error creating website: #{result[:errormessage]}" unless result[:exitcode] == 0
+    Puppet.err "Error creating website: #{result[:errormessage]}" unless result[:errormessage].nil?
+
+    return exists?
+  end
+
+  def destroy
+    inst_cmd = "Remove-Website -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+    result   = self.class.run(inst_cmd)
+    Puppet.err "Error destroying website: #{result[:errormessage]}" unless result[:exitcode] == 0
+    Puppet.err "Error destroying website: #{result[:errormessage]}" unless result[:errormessage].nil?
+    return exists?
+  end
+
+  def exists?
+    inst_cmd = "Get-Website -Name '\"#{@resource[:name]}\"'"
+    result   = self.class.run(inst_cmd)
+    
+    resp = result[:stdout]
+    if resp.nil?
+      return false
+    else
+      return true
+    end
+  end
+
+  def start
+    create if ! exists?
+    @resource[:ensure]  = 'started'
+
+    inst_cmd = "Start-Website -Name \"#{@resource[:name]}\""
+    result   = self.class.run(inst_cmd)
+    Puppet.err "Error starting website: #{result[:errormessage]}" unless result[:errormessage].nil?
+    
+    resp     = result[:stdout]
+    if resp.nil?
+      return true
+    else
+      return false
+    end
+  end
+
+  def stop
+    create if ! exists?
+    @resource[:ensure] = 'stopped'
+
+    inst_cmd = "Stop-Website -Name \"#{@resource[:name]}\""
+    result   = self.class.run(inst_cmd)
+    Puppet.err "Error stopping website: #{result[:errormessage]}" unless result[:errormessage].nil?
+    
+    resp = result[:stdout]
+    if resp.nil?
+      return true
+    else
+      return false
+    end
+  end
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def self.prefetch(resources)
+    sites = instances
+    resources.keys.each do |site|
+      if provider = sites.find{ |s| s.name == site }
+        resources[site].provider = provider
+      end
+    end
+  end
+
+  def self.instances
+    inst_cmd = ps_script_content('_getwebsites', @resource)
+    result   = run(inst_cmd)
+    text     = result[:stdout]
+
+    site_json = JSON.parse(text)
+    site_json = [site_json] if site_json.is_a?(Hash)
+    site_json.collect do |site|
+      site_hash = {}
+
+      site_hash[:ensure]               = site['state'].downcase
+      site_hash[:name]                 = site['name']
+      site_hash[:physicalpath]         = site['physicalpath']
+      site_hash[:applicationpool]      = site['applicationpool']
+      site_hash[:serverautostart]      = to_bool(site['serverautostart'].downcase) unless site['serverautostart'].empty?
+      site_hash[:enabledprotocols]     = site['enabledprotocols']
+      site_hash[:logpath]              = site['logpath']
+      site_hash[:logperiod]            = site['logperiod']
+      site_hash[:logtruncatesize]      = site['logtruncatesize']
+      site_hash[:loglocaltimerollover] = to_bool(site['loglocaltimerollover'].downcase) unless site['loglocaltimerollover'].empty?
+      site_hash[:logformat]            = site['logformat']
+      site_hash[:logflags]             = site['logextfileflags']
+
+      new(site_hash)
+    end
+  end
+
+  def self.to_bool(value)
+    return true   if value == true   || value =~ (/(true|t|yes|y|1)$/i)
+    return false  if value == false  || value =~ (/(false|f|no|n|0)$/i)
+    raise ArgumentError.new("invalid value for Boolean: \"#{value}\"")
+  end
+
+  def self.run(command, check = false)
+    result = ps_manager.execute(command)
+
+    stdout      = result[:stdout]
+    stderr      = result[:stderr]
+    exit_code   = result[:exitcode]
+
+    unless stderr.nil?
+      stderr.each do |er|
+        er.each { |e| Puppet.debug "STDERR: #{e.chop}" } unless er.empty?
+      end
+    end
+
+
+    Puppet.debug "STDOUT: #{result[:stdout]}" unless result[:stdout].nil?
+    Puppet.debug "STDERR: #{result[:errormessage]}" unless result[:errormessage].nil?
+
+    return result
+  end
+
+  def self.ps_manager
+    PuppetX::IIS::PowerShellManager.instance("#{command(:powershell)} #{PuppetX::IIS::PowerShellCommon.powershell_args.join(' ')}")
+  end
+
+  def self.ps_script_content(template, resource)
+    @param_hash = resource
+    template_path = File.expand_path('../../templates', __FILE__)
+    template_file = File.new(template_path + "/webadministration/#{template}.ps1.erb").read
+    template      = ERB.new(template_file, nil, '-')
+    template.result(binding)
+  end
+end

--- a/lib/puppet/provider/templates/iisadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/iisadministration/_getwebsites.ps1.erb
@@ -1,0 +1,26 @@
+Get-IISSite | %{
+  [PSCustomObject]@{
+    name             = [string]$_.Name
+    path             = [string]$_.PhysicalPath
+    applicationpool  = [string]$_.ApplicationPool
+    hostheader       = [string]$_.HostHeader
+    state            = [string]$_.State
+    serverautostart  = [string]$_.serverautostart
+    enabledprotocols = [string]$_.enabledprotocols
+    bindings         = @($_.Bindings.Collection | %{
+      [PSCustomObject]@{
+        protocol             = [string]$_.protocol
+        bindinginformation   = [string]$_.bindingInformation
+        sslflags             = [string]$_.sslFlags
+        certificatehash      = [string]$_.certificateHash
+        certificatestorename = [string]$_.certificateStoreName
+      }
+    })
+    logformat            = [string]$_.LogFile.logFormat
+    logpath              = [string]$_.LogFile.directory
+    logperiod            = [string]$_.LogFile.period
+    logtruncatesize      = [string]$_.LogFile.truncateSize
+    loglocaltimerollover = [string]$_.LogFile.localTimeRollover
+    logextfileflags      = [string]$_.LogFile.logExtFileFlags
+  }
+} | ConvertTo-Json -Depth 10

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -1,0 +1,28 @@
+# TODO: this is JSON, PS v2 doesnt support it
+# PSCustomObject isnt present in v2
+Get-WebSite | %{
+  [PSCustomObject]@{
+    name             = [string]$_.Name
+    path             = [string]$_.PhysicalPath
+    applicationpool  = [string]$_.ApplicationPool
+    hostheader       = [string]$_.HostHeader
+    state            = [string]$_.State
+    serverautostart  = [string]$_.serverautostart
+    enabledprotocols = [string]$_.enabledprotocols
+    bindings         = @($_.Bindings.Collection | %{
+      [PSCustomObject]@{
+        protocol             = [string]$_.protocol
+        bindinginformation   = [string]$_.bindingInformation
+        sslflags             = [string]$_.sslFlags
+        certificatehash      = [string]$_.certificateHash
+        certificatestorename = [string]$_.certificateStoreName
+      }
+    })
+    logformat            = [string]$_.LogFile.logFormat
+    logpath              = [string]$_.LogFile.directory
+    logperiod            = [string]$_.LogFile.period
+    logtruncatesize      = [string]$_.LogFile.truncateSize
+    loglocaltimerollover = [string]$_.LogFile.localTimeRollover
+    logextfileflags      = [string]$_.LogFile.logExtFileFlags
+  }
+} | ConvertTo-Json -Depth 10

--- a/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
@@ -1,0 +1,43 @@
+$resource = @{
+  name            = '<%= "#{resource[:name]}" %>'
+  ensure          = '<%= "#{resource[:ensure]}" %>'
+  physicalpath    = '<%= "#{resource[:physicalpath]}" %>'
+  applicationpool = '<%= "#{resource[:applicationpool]}" %>'
+}
+
+$createParams = @{
+  Name            = $resource.name
+  PhysicalPath    = $resource.physicalpath
+  ApplicationPool = $resource.applicationpool
+  Force           = $true
+  ErrorAction     = 'Stop'
+}
+
+# If there are no other websites, specify the Id
+# if (-not (Get-Website)){
+#   $createParams['Id'] = 1
+# }
+
+# create website
+# dont set applicationpool if it doesnt exist
+New-Website @createParams
+
+function Try-SetItemProperty
+{
+  param($Path, $Name, $Value)
+
+  $existing = Get-ItemProperty -Path $Path -Name $Name -ErrorAction 'Continue'
+
+  if(($existing -eq $null) -or ($existing.Value -ne $Value)){
+
+    try {
+      Set-ItemProperty -Path $Path -Name $Name -Value $Value
+    }catch{
+      throw "Error setting $($Name) to $($Value): $($_)"
+    }
+
+  }else{
+    # NOOP
+  }
+
+}

--- a/lib/puppet/provider/templates/webadministration/generalproperties.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/generalproperties.ps1.erb
@@ -1,0 +1,41 @@
+<% if !resource[:defaultpage].nil? -%>
+$resource.defaultpage = @('<%= "#{resource[:defaultpage].join("','")}" %>')
+$AllDefaultPages = @(
+  Get-WebConfiguration -Filter '//defaultDocument/files/*' -PSPath "IIS:\Sites\$($resource.name)" |
+    ForEach-Object { $_.value }
+)
+$resource.defaultpage | %{
+  if ($AllDefaultPages -inotcontains $_){
+    Add-WebConfiguration -Filter '//defaultDocument/files' `
+                         -PSPath "IIS:\Sites\$($resource.name)" `
+                         -Value @{value = $_}
+  }
+}
+<% end -%>
+
+<% if !resource[:enabledprotocols].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'enabledProtocols'
+  Value = '<%= "#{resource[:enabledprotocols]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:serviceautostart].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'applicationDefaults.serviceAutoStartEnabled'
+  Value = '<%= "#{resource[:serviceautostart]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:preloadenabled].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'applicationDefaults.serviceAutoStartEnabled'
+  Value = '<%= "#{resource[:preloadenabled]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>

--- a/lib/puppet/provider/templates/webadministration/logproperties.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/logproperties.ps1.erb
@@ -1,0 +1,61 @@
+<% if !resource[:logformat].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'LogFile.logFormat'
+  Value = '<%= "#{resource[:logformat]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:logpath].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'LogFile.directory'
+  value = '<%= "#{resource[:logpath]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:logflags].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'LogFile.logFormat'
+  value = 'W3C'
+}
+Try-SetItemProperty @logParams
+
+$logParams.Name  = 'LogFile.LogExtFileFlags'
+$logParams.value = '<%= "#{resource[:logflags]}" %>'
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:logperiod].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'LogFile.period'
+  value = '<%= "#{resource[:logperiod]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:logtruncatesize].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'LogFile.truncateSize'
+  value = '<%= "#{resource[:logtruncatesize]}" %>'
+}
+Try-SetItemProperty @logParams
+
+$logParams.Name  = 'LogFile.period'
+$logParams.value = 'MaxSize'
+Try-SetItemProperty @logParams
+<% end -%>
+
+<% if !resource[:loglocaltimerollover].nil? -%>
+$logParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'LogFile.localTimeRollover'
+  value = '<%= "#{resource[:loglocaltimerollover]}" %>'
+}
+Try-SetItemProperty @logParams
+<% end -%>

--- a/lib/puppet/provider/templates/webadministration/serviceautostartprovider.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/serviceautostartprovider.ps1.erb
@@ -1,0 +1,38 @@
+<% if !resource[:serviceautostartprovidername].nil? -%>
+$resource.serviceautostartprovidername = '<%= "#{resource[:serviceautostartprovidername]}" %>'
+$resource.serviceautostartprovidertype = '<%= "#{resource[:serviceautostartprovidertype]}" %>'
+
+$provider = @(New-Object -TypeName PSObject -Property @{
+  Name = $resource.serviceautostartprovidername
+  Type = $resource.serviceautostartprovidertype
+})
+
+$website = Get-Website -Name '<%= "#{resource[:name]}" %>' -ErrorAction 'Continue'
+
+if($website){
+  $current = $website.applicationDefaults.ServiceAutoStartProvider
+
+  if(($provider.name) -and ($current -ne $provider.name)){
+    $webConfig = (Get-WebConfiguration -filter '/system.applicationHost/serviceAutoStartProviders').Collection
+    $existing  = $webConfig | Where-Object { $_.Name -eq $provider.name } | Select-Object Name,Type
+    
+    if($existing){
+      if($existing.name -ne $provider.name){
+        if($existing.type -ne $provider.type){
+          throw 'The specified AutoStartProvider is the same as a Global Property.
+                  Ensure that the serviceAutoStartProvider is unique'
+        }
+      }
+    }else{
+      Add-WebConfiguration -Filter "/system.applicationHost/serviceAutoStartProviders" `
+                           -Value $provider `
+                           -ErrorAction 'Stop'
+    }
+    
+    Set-ItemProperty -Path "IIS:\Sites\<%= "#{resource[:name]}" %>" `
+                     -Name 'applicationDefaults.serviceAutoStartProvider' `
+                     -Value $provider.name `
+                     -ErrorAction Stop
+  }
+}
+<% end -%>

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,0 +1,270 @@
+require 'puppet/parameter/boolean'
+
+Puppet::Type.newtype(:iis_site) do
+  @doc = "Create a new IIS website."
+
+  newproperty(:ensure) do
+    desc "Specifies whether a site should be present or absent. If present is
+      specified, the site will be created but left in the default stopped state.
+      If started is specified, then the site will be created as well as started.
+      If stopped is specified, then the site will be created and kept stopped."
+
+    newvalue(:stopped) do
+      provider.stop
+    end
+
+    newvalue(:started) do
+      provider.start
+    end
+
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      provider.destroy
+    end
+
+    aliasvalue(:false, :stopped)
+    aliasvalue(:true, :started)
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "The Name of the IIS site. Used for uniqueness. Will set
+      the target to this value if target is unset."
+
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty name must be specified."
+      end
+      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+    end
+  end
+
+  newproperty(:physicalpath) do
+    desc 'The physical path to the IIS web site folder'
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty physicalpath must be specified."
+      end
+      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
+    end
+  end
+
+  newproperty(:applicationpool) do
+    desc 'The name of an ApplicationPool for this IIS Web Site'
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty applicationpool name must be specified."
+      end
+      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+    end
+  end
+
+  newproperty(:enabledprotocols) do
+    desc 'The protocols enabled for this site. If https is specified, http is implied.
+      If no value is provided, then this setting is disabled'
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['http','https'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are http, https")
+      end
+    end
+  end
+
+  newproperty(:serviceautostart, :boolean => true) do
+    desc 'Enables autostart on the specified website'
+    newvalue(:true)
+    newvalue(:false)
+
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:serviceautostartprovidername) do
+    desc 'Specifies the provider used for service auto start. Used with :serviceautostartprovidertype.
+    The <serviceAutoStartProviders> element specifies a collection of managed assemblies that
+    Windows Process Activation Service (WAS) will load automatically when the startMode attribute of an
+    application pool is set to AlwaysRunning. This collection allows developers to specify assemblies that perform
+    initialization tasks before any HTTP requests are serviced.
+    
+    example:
+    serviceautostartprovidername => "MyAutostartProvider"
+    serviceautostartprovidertype => "MyAutostartProvider, MyAutostartProvider, version=1.0.0.0, Culture=neutral, PublicKeyToken=426f62526f636b73"
+    '
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty serviceautostartprovidername name must be specified."
+      end
+      fail("#{name} is not a valid serviceautostartprovidername name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+    end
+    # serviceautostartprovidertype and serviceautostartprovidername work together
+  end
+
+  newproperty(:serviceautostartprovidertype) do
+    # serviceautostartprovidertype and serviceautostartprovidername work together
+    desc 'Specifies the application type for the provider used for service auto start. Used with :serviceautostartprovider
+    example:
+    serviceautostartprovidername => "MyAutostartProvider"
+    serviceautostartprovidertype => "MyAutostartProvider, MyAutostartProvider, version=1.0.0.0, Culture=neutral, PublicKeyToken=426f62526f636b73"
+    '
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty serviceautostartprovidertype name must be specified."
+      end
+      # fail("#{name} is not a valid serviceautostartprovidertype name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+    end
+    
+  end
+
+  newproperty(:preloadenabled, :boolean => true) do
+    desc 'Enables loading website automatically without a client request first'
+    newvalue(:true)
+    newvalue(:false)
+
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:defaultpage, :array_matching => :all) do
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty defaultpage must be specified."
+      end
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  newproperty(:logformat) do
+    desc 'Specifies the format for the log file. When set to WSC,
+      it can be used in conjunction with :logflags'
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['W3C','IIS','NCSA'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are W3C, IIS, NCSA")
+      end
+    end
+  end
+
+  newproperty(:logpath) do
+    desc 'Specifies the physical path to place the log file'
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty logpath must be specified."
+      end
+      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
+    end
+  end
+
+  newproperty(:logperiod) do
+    desc 'Specifies how often the log file should rollover'
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Hourly','Daily','Weekly','Monthly','MaxSize'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Hourly, Daily, Weekly, Monthly, MaxSize")
+      end
+    end
+  end
+
+  newproperty(:logtruncatesize) do
+    desc 'Specifies how large the log file should be before truncating it.
+      The value must be in bytes. The value can be any size
+      between \'1048576 (1MB)\' and \'4294967295 (4GB)\'.
+      '
+    validate do |value|
+      unless value.kind_of?(Integer)
+        fail("Invalid value '#{value}'. Should be a number")
+      end
+      if value < 1048576 or value > 4294967295
+        fail("Invalid value '#{value}'. Cannot be less than 1048576 or greater than 4294967295")
+      end
+    end
+  end
+
+  newproperty(:loglocaltimerollover, :boolean => true) do
+    desc 'Use the system\'s local time to determine for the log file name as
+       as well as when the log file is rolled over'
+    newvalue(:true)
+    newvalue(:false)
+
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+
+  newproperty(:logflags, :array_matching => :all) do
+    desc 'Specifies what W3C fields are logged in the IIS log file. This is only
+      valid when :logformat is set to W3C. '
+    validate do |value|
+      # if value.nil? or value.empty?
+      #   raise ArgumentError, "A non-empty defaultpage must be specified."
+      # end
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless [
+        'Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP',
+        'Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent',
+        'BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer',
+        'ProtocolVersion','Host','HttpSubStatus'
+        ].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Date, Time, ClientIP,
+             UserName, SiteName, ComputerName, ServerIP,
+             Method, UriStem, UriQuery, HttpStatus, Win32Status, BytesSent,
+             BytesRecv, TimeTaken, ServerPort, UserAgent, Cookie, Referer,
+             ProtocolVersion, Host, HttpSubStatus")
+      end
+    end
+  end
+
+  validate do
+    # TODO: These need validation
+    # logperiod and logtruncatesize
+    # logtruncatesize needs int range validation
+    # logflags need to support 4 values and no value
+    # enabledprotocols need to support 2 values and no value
+
+    # TODO: need check if logperiod is not MaxSize if logtruncatesize is set. if not
+    if self[:logperiod] && self[:logtruncatesize]
+      fail("Cannot specify logperiod and logtruncatesize at the same time")
+    end
+
+    # can only use logflags if logformat is W3C
+    if self[:logflags]
+      unless ['W3C','w3c'].include?(self[:logformat])
+        fail("Cannot specify logflags when logformat is not W3C")
+      end
+    end
+    
+    if self[:serviceautostartprovidername]
+      fail("Must specify serviceautostartprovidertype as well as serviceautostartprovidername") unless self[:serviceautostartprovidertype]
+    end
+    
+    if self[:serviceautostartprovidertype]
+      fail("Must specify serviceautostartprovidername as well as serviceautostartprovidertype") unless self[:serviceautostartprovidername]
+    end
+
+    provider.validate if provider.respond_to?(:validate)
+  end
+
+  def munge_boolean(value)
+    case value
+      when true, "true", :true
+        :true
+      when false, "false", :false
+        :false
+      else
+        fail("munge_boolean only takes booleans")
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/iis/powershell_common.rb
+++ b/lib/puppet_x/puppetlabs/iis/powershell_common.rb
@@ -1,0 +1,24 @@
+module PuppetX
+  module IIS
+    module PowerShellCommon
+      
+      def powershell_path
+        path = if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")
+                "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
+              elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
+                "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
+              else
+                'powershell.exe'
+              end
+        path
+      end
+      module_function :powershell_path
+      
+      def powershell_args
+        ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command', '-']
+        ps_args
+      end
+      module_function :powershell_args
+    end
+  end
+end

--- a/spec/unit/puppet/provider/iis_site/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_site/webadministration_spec.rb
@@ -1,0 +1,35 @@
+describe Puppet::Type.type(:iis_site).provider(:webadministration), :if => Puppet.features.microsoft_windows? do
+  let(:resource) { Puppet::Type.type(:iis_site).new(:name => "iis_site") }
+  let(:provider) { resource.provider }
+  let(:catalog)  { Puppet::Resource::Catalog.new }
+  
+  before :each do
+    resource.provider = provider
+  end
+
+  context "verify provider" do
+    it "should be an instance of Puppet::Type::Iis_site::ProviderWebadministration" do
+      provider.must be_an_instance_of Puppet::Type::Iis_site::ProviderWebadministration
+    end
+
+    it "should have a create method" do
+      provider.should respond_to(:create)
+    end
+
+    it "should have an exists? method" do
+      provider.should respond_to(:exists?)
+    end
+
+    it "should have a destroy method" do
+      provider.should respond_to(:destroy)
+    end
+    
+    it "should have a start method" do
+      provider.should respond_to(:start)
+    end
+    
+    it "should have a stop method" do
+      provider.should respond_to(:stop)
+    end
+  end
+end

--- a/spec/unit/type/iis_site_spec.rb
+++ b/spec/unit/type/iis_site_spec.rb
@@ -1,0 +1,499 @@
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/type/iis_site'
+
+describe Puppet::Type.type(:iis_site) do
+  let(:resource) { Puppet::Type.type(:iis_site).new(:name => "iis_site") }
+  let(:provider) { Puppet::Provider.new(resource) }
+  let(:catalog)  { Puppet::Resource::Catalog.new }
+
+  before :each do
+    resource.provider = provider
+  end
+
+  it "should be an instance of Puppet::Type::Iis_site" do
+    expect(resource).to be_a_kind_of Puppet::Type::Iis_site
+  end
+
+  context "parameter :name" do
+    it "should be the name var" do
+      expect(resource.parameters[:name].isnamevar?).to be true
+    end
+
+    it "should not allow nil" do
+      expect {
+        resource[:name] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for name/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:name] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty name must/)
+    end
+
+    it "should accept any string value" do
+      resource[:name] = 'value'
+      resource[:name] = "thisstring-location"
+    end
+  end
+
+  context "parameter :physicalpath" do
+    it "should not allow nil" do
+      expect {
+        resource[:physicalpath] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for physicalpath/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:physicalpath] = ''
+      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified./)
+    end
+
+    it "should accept any string value" do
+      resource[:physicalpath] = "c:/thisstring-location/value/somefile.txt"
+      resource[:physicalpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    end
+  end
+
+  context "parameter :applicationpool" do
+    it "should not allow nil" do
+      expect {
+        resource[:applicationpool] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for applicationpool/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:applicationpool] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty applicationpool name must be specified./)
+    end
+
+    it "should accept any string value" do
+      resource[:applicationpool] = 'value'
+      resource[:applicationpool] = "thisstring-location"
+    end
+  end
+
+  context "parameter :enabledprotocols" do
+    it "should not allow nil" do
+      expect {
+        resource[:enabledprotocols] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for enabledprotocols/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:enabledprotocols] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https/)
+    end
+
+    it "should accept valid string value" do
+      resource[:enabledprotocols] = ['http','https']
+      resource[:enabledprotocols] = 'http'
+      resource[:enabledprotocols] = 'https'
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:enabledprotocols] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Valid values are http, https/)
+    end
+  end
+  
+  context "parameter :serviceautostart" do
+    it "should accept :true" do
+      resource[:serviceautostart] = :true
+    end
+
+    it "should accept :false" do
+      resource[:serviceautostart] = :false
+    end
+
+    it "should reject non-boolean values" do
+      expect {
+        resource[:serviceautostart] = :whenever
+      }.to raise_error(Puppet::ResourceError, /Invalid value :whenever. Valid values are true, false./)
+    end
+
+    it "should not allow nil" do
+      expect {
+        resource[:serviceautostart] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for serviceautostart/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:serviceautostart] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value "". Valid values are true, false./)
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:serviceautostart] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value "woot". Valid values are true, false./)
+    end
+  end
+  
+  context "parameter :serviceautostartprovidername" do
+    it "should not allow nil" do
+      expect {
+        resource[:serviceautostartprovidername] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for serviceautostartprovidername/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:serviceautostartprovidername] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty serviceautostartprovidername name must be specified./)
+    end
+
+    it "should accept any string value" do
+      resource[:serviceautostartprovidername] = 'value'
+      resource[:serviceautostartprovidername] = "thisstring-location"
+    end
+  end
+  
+  context "parameter :serviceautostartprovidertype" do
+    it "should not allow nil" do
+      expect {
+        resource[:serviceautostartprovidertype] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for serviceautostartprovidertype/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:serviceautostartprovidertype] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty serviceautostartprovidertype name must be specified./)
+    end
+
+    it "should accept any string value" do
+      resource[:serviceautostartprovidertype] = 'value'
+      resource[:serviceautostartprovidertype] = "thisstring-location"
+    end
+  end
+  
+  context "parameter :preloadenabled" do 
+    it "should accept :true" do
+      resource[:preloadenabled] = :true
+    end
+
+    it "should accept :false" do
+      resource[:preloadenabled] = :false
+    end
+
+    it "should reject non-boolean values" do
+      expect {
+        resource[:preloadenabled] = :whenever
+      }.to raise_error(Puppet::ResourceError, /Invalid value :whenever. Valid values are true, false./)
+    end
+
+    it "should not allow nil" do
+      expect {
+        resource[:preloadenabled] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for preloadenabled/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:preloadenabled] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value "". Valid values are true, false./)
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:preloadenabled] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value "woot". Valid values are true, false./)
+    end
+  end
+  
+  context "parameter :defaultpage" do
+    it "should not allow nil" do
+      expect {
+        resource[:defaultpage] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for defaultpage/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:defaultpage] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty defaultpage must be specified./)
+    end
+
+    it "should accept valid string value and string array" do
+      resource[:defaultpage] = ['wakka','foo']
+      resource[:defaultpage] = 'default.htm'
+    end
+  end
+
+  context "parameter :logformat" do
+    it "should not allow nil" do
+      expect {
+        resource[:logformat] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for logformat/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:logformat] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are W3C, IIS, NCSA/)
+    end
+
+    it "should accept valid string value" do
+      resource[:logformat] = ['W3C','IIS']
+      resource[:logformat] = 'W3C'
+      resource[:logformat] = 'IIS'
+      resource[:logformat] = 'NCSA'
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:logformat] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Valid values are W3C, IIS, NCSA/)
+    end
+  end
+
+  context "parameter :logpath" do
+    it "should not allow nil" do
+      expect {
+        resource[:logpath] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for logpath/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:logpath] = ''
+      }.to raise_error(Puppet::Error, /A non-empty logpath must be specified./)
+    end
+
+    it "should accept any string value" do
+      resource[:logpath] = "c:/thisstring-location/value/somefile.txt"
+      resource[:logpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    end
+  end
+
+  context "parameter :logperiod" do
+    it "should not allow nil" do
+      expect {
+        resource[:logperiod] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for logperiod/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:logperiod] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are Hourly, Daily, Weekly, Monthly, MaxSize/)
+    end
+
+    it "should accept valid string value" do
+      resource[:logperiod] = ['Hourly','Daily']
+      resource[:logperiod] = 'Hourly'
+      resource[:logperiod] = 'Daily'
+      resource[:logperiod] = 'Weekly'
+      resource[:logperiod] = 'Monthly'
+      resource[:logperiod] = 'MaxSize'
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:logperiod] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Valid values are Hourly, Daily, Weekly, Monthly, MaxSize/)
+    end
+  end
+  
+  context "parameter :logtruncatesize" do
+    it "should not allow nil" do
+      expect {
+        resource[:logtruncatesize] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for logtruncatesize/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:logtruncatesize] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Should be a number/)
+    end
+    
+    it "should not accept invalid int value" do
+      expect {
+        resource[:logtruncatesize] = 128576
+      }.to raise_error(Puppet::ResourceError, /Invalid value '128576'. Cannot be less than 1048576 or greater than 4294967295/)
+      expect {
+        resource[:logtruncatesize] = 5298967295
+      }.to raise_error(Puppet::ResourceError, /Invalid value '5298967295'. Cannot be less than 1048576 or greater than 4294967295/)
+    end
+
+    it "should accept valid int value" do
+      resource[:logtruncatesize] = 1048576
+      resource[:logtruncatesize] = 4294967295
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:logtruncatesize] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Should be a number/)
+    end
+  end
+  
+  context "parameter :loglocaltimerollover" do
+    it "should accept :true" do
+      resource[:loglocaltimerollover] = :true
+    end
+
+    it "should accept :false" do
+      resource[:loglocaltimerollover] = :false
+    end
+
+    it "should reject non-boolean values" do
+      expect {
+        resource[:loglocaltimerollover] = :whenever
+      }.to raise_error(Puppet::ResourceError, /Invalid value :whenever. Valid values are true, false./)
+    end
+
+    it "should not allow nil" do
+      expect {
+        resource[:loglocaltimerollover] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for loglocaltimerollover/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:loglocaltimerollover] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value "". Valid values are true, false./)
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:loglocaltimerollover] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value "woot". Valid values are true, false./)
+    end
+  end
+
+  context "parameter :logflags" do
+    it "should not allow nil" do
+      expect {
+        resource[:logflags] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for logflags/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:logflags] = ''
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are Date, Time, ClientIP,
+             UserName, SiteName, ComputerName, ServerIP,
+             Method, UriStem, UriQuery, HttpStatus, Win32Status, BytesSent,
+             BytesRecv, TimeTaken, ServerPort, UserAgent, Cookie, Referer,
+             ProtocolVersion, Host, HttpSubStatus/)
+    end
+
+    it "should accept valid string value" do
+      resource[:logflags] = ['Date','Time']
+      resource[:logflags] = 'Date'
+      resource[:logflags] = 'Time'
+      resource[:logflags] = 'ClientIP'
+    end
+
+    it "should not accept invalid string value" do
+      expect {
+        resource[:logflags] = 'woot'
+      }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Valid values are Date, Time, ClientIP,
+             UserName, SiteName, ComputerName, ServerIP,
+             Method, UriStem, UriQuery, HttpStatus, Win32Status, BytesSent,
+             BytesRecv, TimeTaken, ServerPort, UserAgent, Cookie, Referer,
+             ProtocolVersion, Host, HttpSubStatus/)
+    end
+  end
+
+  context "mulitple parameter validation" do
+
+    it "should not allow logperiod and logtruncatesize to be specified at same time" do
+      expect {
+        resource[:logperiod] = 'Daily'
+        resource[:logtruncatesize] = 1048576
+        resource.validate
+      }.to raise_error(Puppet::Error, /Cannot specify logperiod and logtruncatesize at the same time/)
+    end
+
+    it "should not allow logflags to be used without logformat set to W3C at same time" do
+      expect {
+        resource[:logflags] = 'Date'
+        resource[:logformat] = 'IIS'
+        resource.validate
+      }.to raise_error(Puppet::Error, /Cannot specify logflags when logformat is not W3C/)
+    end
+
+    it "should not allow either serviceautostartprovidername or serviceautostartprovidertype to be specified without the other" do
+      expect {
+        resource[:serviceautostartprovidername] = 'foo'
+        resource.validate
+      }.to raise_error(Puppet::Error, /Must specify serviceautostartprovidertype as well as serviceautostartprovidername/)
+    end
+
+  end
+  # context "parameter :state" do
+  #   it "should not allow nil" do
+  #     expect {
+  #       resource[:state] = nil
+  #     }.to raise_error(Puppet::Error, /Got nil value for state/)
+  #   end
+
+  #   it "should not allow empty" do
+  #     expect {
+  #       resource[:state] = ''
+  #     }.to raise_error(Puppet::ResourceError, /A non-empty state must be specified./)
+  #   end
+
+  #   it "should not allow anything other than stopped|started" do
+  #     expect {
+  #       resource[:state] = 'foo'
+  #     }.to raise_error(Puppet::ResourceError, /Invalid value 'foo'. Valid values are started, stopped/)
+  #   end
+
+  #   it "should accept only started|stopped string value" do
+  #     resource[:state] = "started"
+  #     resource[:state] = "Started"
+  #     resource[:state] = "stopped"
+  #     resource[:state] = "Stopped"
+  #   end
+  # end
+
+end
+
+# iis_site{'foobar':
+#   ensure          => 'started',
+#   path            => 'c:\inetpub\foobar',
+#   applicationpool => 'foo',
+#   bindinginfo     => [
+#     {
+#       protocol              => 'http',
+#       ipaddress             => '192.168.0.1',
+#       port                  => 80,
+#       hostname              => '',
+#       certificatethumbprint => '',
+#       certificatestorename  => '',
+#       sslflags              => '',
+#     },
+#     {
+#       protocol              => 'https'
+#       binding               => '192.168.0.1:443:foo',
+#       certificatethumbprint => '',
+#       certificatestorename  => '',
+#       sslflags              => '',
+#     }
+#   ],
+#   defaultpage                  => [],
+#   enabledprotocols             => '',
+#   authenticationinfo           => '',
+#   preloadenabled               => '',
+#   serviceautostart             => false,
+#   serviceautostartprovidername => '',
+#   serviceautostartprovidertype => '',
+#   preloadenabled               => false,,
+#   logpath                      => '',
+#   logflags                     => [],
+#   logperiod                    => '',
+#   logtruncatesize              => '',
+#   loglocaltimerollover         => false,
+#   logformat                    => '',
+# }


### PR DESCRIPTION
Add a type and provider for listing, creating and deleting IIS Websites. This does not
handle setting binding information for a site, this is covered in MODULES-3639
- [x]  PowerShell WebAdministration ModuleProvider
- [x]  Create, Modify, Delete iis sites
- [x]  Service Auto Start Provider
- [x]  Unit tests for type and provider
- [x]  IIS version Fact
- [x]  Confines for IIS and OS version for 2016
