### PR TITLE
Initial layout for acceptance testing

### DIFF
--- a/spec/acceptance/iis_minimal_config_spec.rb
+++ b/spec/acceptance/iis_minimal_config_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper_acceptance'
+
+describe 'a minimal IIS config:' do
+  before(:all) do
+    @manifest = <<-EOF
+      # iis_site { "minimal": }
+      notify { "something should happen here": }
+    EOF
+    @result = apply_manifest(@manifest, acceptable_exit_codes: (0...256))
+  end
+
+  it_behaves_like 'an idempotent resource'
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,18 @@
+---
+HOSTS:
+  windows2012-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: windows-2012-64
+    ruby_arch: x64
+    template: win-2012-x86_64
+    roles:
+    - agent
+    - default
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/spec/acceptance/nodesets/windows2008r2.yml
+++ b/spec/acceptance/nodesets/windows2008r2.yml
@@ -1,0 +1,18 @@
+---
+HOSTS:
+  windows2008r2-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: windows-2008r2-64
+    ruby_arch: x64
+    template: win-2008r2-x86_64
+    roles:
+    - agent
+    - default
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,10 +2,12 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'
 
+# automatically load any shared examples or contexts
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
 run_puppet_install_helper
 
 unless ENV['MODULE_provision'] == 'no'
-
   on default, "mkdir -p #{default['distmoduledir']}/powershell"
   result = on default, "echo #{default['distmoduledir']}/powershell"
   target = result.raw_output.chomp
@@ -17,9 +19,6 @@ end
 
 RSpec.configure do |c|
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
-  # Readable test descriptions
-  c.formatter = :documentation
 
   # Configure all nodes in nodeset
   c.before :suite do

--- a/spec/support/examples/idempotent_resource.rb
+++ b/spec/support/examples/idempotent_resource.rb
@@ -1,0 +1,10 @@
+shared_examples 'an idempotent resource' do
+  it 'should run without errors' do
+    expect(@result.exit_code).to eq 2
+  end
+
+  it 'should run a second time without changes' do
+    second_result = apply_manifest(@manifest, acceptable_exit_codes: (0...256))
+    expect(second_result.exit_code).to eq 0
+  end
+end


### PR DESCRIPTION
The tests in this commit are already running successfully to the point
where the notify is causing a failure on the target agent.

The nodesets still need to be improved to use vagrant images instead of
the vmpooler reference.