### PR TITLE
(maint) Fix running spec tests with fixtures

### DIFF
--- a/.fixtures.yaml
+++ b/.fixtures.yaml
@@ -1,0 +1,4 @@
+fixtures:
+  forge_modules:
+  symlinks:
+    "iis": "#{source_dir}"

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -20,7 +20,7 @@ if Puppet.features.microsoft_windows?
 end
 
 RSpec.configure do |config|
-  tmpdir = Dir.mktmpdir("rspecrun_powershell")
+  tmpdir = Dir.mktmpdir("rspecrun_iis")
   oldtmpdir = Dir.tmpdir()
   ENV['TMPDIR'] = tmpdir
 


### PR DESCRIPTION
This adds a .fixutres.yaml file to help symlinking the module when
running spec tests. It also fixes the spec_helper file to point to iis
and not powershell