### PR TITLE
Extend wait time to reduce debug output

### DIFF
--- a/lib/puppet_x/puppetlabs/iis/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/iis/powershell_manager.rb
@@ -169,7 +169,7 @@ Invoke-PowerShellUserCode @params
       WAIT_TIMEOUT = 0x00000102
       WAIT_FAILED = 0xFFFFFFFF
 
-      def self.wait_on(wait_object, timeout_ms = 50)
+      def self.wait_on(wait_object, timeout_ms = 1000)
         wait_result = WaitForSingleObject(wait_object, timeout_ms)
 
         case wait_result


### PR DESCRIPTION
The original timeout of 50ms would create hundreds of lines of debug
output. This reduces that amount 20-fold, by printing a message every
second.