### PR TITLE
(MODULES-4219) Add Create/Destroy to IIS App Pool

### DIFF
--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -10,26 +10,50 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
   commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path
 
   mk_resource_methods
-
+  
   def create
+    inst_cmd = "New-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+    result   = self.class.run(inst_cmd)
+    Puppet.err "Error creating apppool: #{result[:errormessage]}" unless result[:exitcode] == 0
+    Puppet.err "Error creating apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
   end
 
   def update
+    inst_cmd = []
+
+    inst_cmd << self.class.ps_script_content('_setapppool', @resource)
+    
+    @resource.properties.select{|rp| rp.name != :ensure && rp.name != :state }.each do |property|
+      inst_cmd << "Invoke-AppCmd -ArgumentList 'set', 'apppool', #{@resource[:name]}, '/#{property.name.to_s}:#{property.value}';"
+    end
+    
+    if !@resource[:state].nil?
+      case @resource[:state]
+      when 'Stopped'
+        inst_cmd << "Stop-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+      when 'Started'
+        inst_cmd << "Start-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+      end
+    end
+    
+    inst_cmd = inst_cmd.join
+    result   = self.class.run(inst_cmd)
+    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless result[:exitcode] == 0
+    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
   end
 
   def destroy
-  end
-
-  def initialize(value={})
-    super(value)
-    @property_flush = {}
+    inst_cmd = "Remove-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+    result   = self.class.run(inst_cmd)
+    Puppet.err "Error destroying apppool: #{result[:errormessage]}" unless result[:exitcode] == 0
+    Puppet.err "Error destroying apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
   end
 
   def self.prefetch(resources)
-    sites = instances
-    resources.keys.each do |site|
-      if provider = sites.find{ |s| s.name == site }
-        resources[site].provider = provider
+    pools = instances
+    resources.keys.each do |pool|
+      if provider = pools.find{ |s| s.name == pool }
+        resources[pool].provider = provider
       end
     end
   end
@@ -38,20 +62,20 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
     inst_cmd = ps_script_content('_getapppools', @resource)
     result   = run(inst_cmd)
     text     = result[:stdout]
+    return [] if text.nil?
 
-    site_json = JSON.parse(text)
-    site_json = [site_json] if site_json.is_a?(Hash)
-    site_json.collect do |site|
-      site_hash = {}
+    pool_json = JSON.parse(text)
+    pool_json = [pool_json] if pool_json.is_a?(Hash)
+    pool_json.collect do |pool|
+      pool_hash = {}
 
-      site_hash[:ensure] = site['state'].downcase
-      site_hash[:name]   = site['name']
-      site_hash[:state]   = site['state']
-      site_hash[:managedPipelineMode]   = site['managedPipelineMode']
-      site_hash[:managedRuntimeVersion]   = site['managedRuntimeVersion']
+      pool_hash[:ensure]                = :present # pool['state'].downcase
+      pool_hash[:name]                  = pool['name']
+      pool_hash[:state]                 = pool['state']
+      pool_hash[:managedpipelinemode]   = pool['managedpipelinemode']
+      pool_hash[:managedruntimeversion] = pool['managedruntimeversion']
 
-      new(site_hash)
+      new(pool_hash)
     end
-    []
   end
 end

--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -29,11 +29,7 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
   end
 
   def flush
-    if @property_hash[:ensure] == :absent
-      destroy
-    elsif @original_values.empty?
-      create
-    else
+    if exists?
       update
     end
   end
@@ -50,7 +46,6 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
         er.each { |e| Puppet.debug "STDERR: #{e.chop}" } unless er.empty?
       end
     end
-
 
     Puppet.debug "STDOUT: #{result[:stdout]}" unless result[:stdout].nil?
     Puppet.debug "ERRMSG: #{result[:errormessage]}" unless result[:errormessage].nil?

--- a/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
@@ -4,7 +4,7 @@ Get-WebConfiguration -Filter '/system.applicationHost/applicationPools/add' | % 
   [PSCustomObject]@{
     name  = [string]$_.Name
     state = [string]$_.State
-    managedPipelineMode = [string]$_.ManagedPipelineMode
-    managedRuntimeVersion = [string]$_.ManagedRuntimeVersion
+    managedpipelinemode = [string]$_.ManagedPipelineMode
+    managedruntimeversion = [string]$_.ManagedRuntimeVersion
   }
 } | ConvertTo-Json -Depth 10

--- a/lib/puppet/provider/templates/webadministration/_setapppool.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_setapppool.ps1.erb
@@ -1,0 +1,16 @@
+function Invoke-AppCmd {
+  [CmdletBinding()]
+  param
+  (
+    [String[]] $ArgumentList
+  )
+
+  $ErrorActionPreference = 'Stop'
+  $appcmdFilePath        = "$env:SystemRoot\System32\inetsrv\appcmd.exe"
+  $appcmdResult          = $(& $appcmdFilePath $ArgumentList)
+  Write-Verbose -Message $appcmdResult
+  if ($LASTEXITCODE -ne 0){
+    $errorMessage = "AppCmd.exe has exited with error code '$($LASTEXITCODE)'"
+    throw $errorMessage
+  }
+}

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -10,15 +10,39 @@ Puppet::Type.newtype(:iis_application_pool) do
     desc "The name of the ApplicationPool."
   end
   
-  newparam(:state, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newproperty(:state, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
     desc "The state of the ApplicationPool."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Started','started','Stopped','stopped'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Started or Stopped")
+      end
+    end
   end
   
-  newparam(:managedpipelinemode, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
-    desc "The managedPipelineMode of the ApplicationPool."
+  newproperty(:managedpipelinemode, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "The managedPipelineMode of the ApplicationPool. First letter has to be capitalized."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Integrated','Classic'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Integrated or Classic")
+      end
+    end
   end
   
-  newparam(:managedruntimeversion, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newproperty(:managedruntimeversion, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
     desc "The managedRuntimeVersion of the ApplicationPool."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['v4.0','v2.0'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Integrated or Classic")
+      end
+    end
   end
 end

--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -1,30 +1,172 @@
 require 'spec_helper_acceptance'
 
 describe 'iis_application_pool' do
-  context 'when configuring an Application Pool' do
-    before(:all) do
-      @manifest = "iis_application_pool { 'test': }"
-      @result = apply_manifest(@manifest, acceptable_exit_codes: (0...256))
+  context 'when configuring an application pool' do
+    context 'with default parameters' do
+      before(:all) do
+        @pool_name = "#{SecureRandom.hex(10)}"
+        @manifest  = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure => 'present'
+          }
+        HERE
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      context 'when puppet resource is run' do
+        before(:all) do
+          @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+        end
+
+        include_context 'with a puppet resource run'
+        puppet_resource_should_show('ensure', 'present')
+      end
+
+      after(:all) do
+        remove_app_pool(@pool_name)
+      end
     end
 
-    after(:all) do
-      # TODO: remove "test" app pool
+    context 'with valid parameters defined' do
+      before(:all) do
+        @pool_name = "#{SecureRandom.hex(10)}"
+        @manifest  = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure                => 'present',
+            managedpipelinemode   => 'Classic',
+            managedruntimeversion => 'v4.0',
+            state                 => 'Stopped'
+          }
+        HERE
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      context 'when puppet resource is run' do
+        before(:all) do
+          @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+        end
+        
+        include_context 'with a puppet resource run'
+        puppet_resource_should_show('ensure', 'present')
+        puppet_resource_should_show('managedpipelinemode', 'Classic')
+        puppet_resource_should_show('managedruntimeversion', 'v4.0')
+        puppet_resource_should_show('state', 'Stopped')
+      end
+
+      after(:all) do
+        remove_app_pool(@pool_name)
+      end
+    end
+
+    context 'with invalid' do
+      context 'state parameter defined' do
+        before(:all) do
+          @pool_name = "#{SecureRandom.hex(10)}"
+          @manifest  = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure  => 'present',
+            state   => 'AnotherTypo'
+          }
+          HERE
+        end
+
+        it_behaves_like 'a failing manifest'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+          end
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure', 'absent')
+        end
+
+        after(:all) do
+          remove_app_pool(@pool_name)
+        end
+      end
+
+      context 'managedpipelinemode parameter defined' do
+        before(:all) do
+          @pool_name = "#{SecureRandom.hex(10)}"
+          @manifest  = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure              => 'present',
+            managedpipelinemode => 'ClassicTypo'
+          }
+          HERE
+        end
+
+        it_behaves_like 'a failing manifest'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+          end
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure', 'absent')
+        end
+
+        after(:all) do
+          remove_app_pool(@pool_name)
+        end
+      end
+    end
+  end
+
+  context 'when starting a stopped application pool' do
+    before(:all) do
+      @pool_name = "#{SecureRandom.hex(10)}"
+      create_app_pool(@pool_name)
+      stop_app_pool(@pool_name)
+      @manifest = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure  => 'present',
+            state   => 'Started'
+          }
+      HERE
     end
 
     it_behaves_like 'an idempotent resource'
 
-    context "when removing the Application Pool" do
+    context 'when puppet resource is run' do
       before(:all) do
-        @manifest = "iis_application_pool { 'test': ensure => absent }"
-        @result = apply_manifest(@manifest, acceptable_exit_codes: (0...256))
+        @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
       end
 
-      it_behaves_like 'an idempotent resource'
+      include_context 'with a puppet resource run'
+      puppet_resource_should_show('ensure', 'present')
+      puppet_resource_should_show('state', 'Started')
     end
+
+    after(:all){
+      remove_app_pool(@pool_name)
+    }
   end
 
-  context 'when puppet resource is run' do
-    include_context 'with a puppet resource run', 'iis_application_pool', 'DefaultAppPool'  # guess work
-    puppet_resource_should_show('ensure', 'present')
+  context 'when removing an application pool' do
+    before(:all) do
+      @pool_name = "#{SecureRandom.hex(10)}"
+      
+      create_app_pool(@pool_name)
+      
+      @manifest = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure => 'absent'
+          }
+      HERE
+    end
+
+    it_behaves_like 'an idempotent resource'
+
+    context 'when puppet resource is run' do
+      before(:all) do
+        @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+      end
+
+      include_context 'with a puppet resource run'
+      puppet_resource_should_show('ensure', 'absent')
+    end
   end
 end

--- a/spec/support/context/puppet_resource_run.rb
+++ b/spec/support/context/puppet_resource_run.rb
@@ -1,7 +1,9 @@
 shared_context 'with a puppet resource run' do |type, name|
-  before(:all) do
-    @result = resource(type, name, beaker_opts)
-  end
+  # before(:all) do
+  #   # @result = resource(type, name, beaker_opts)
+  #   require 'pry';binding.pry
+  #   @result = on(default, puppet('resource', type, name))
+  # end
 
   it 'should return successfully' do
     expect(@result.exit_code).to eq 0

--- a/spec/support/examples/failing_manifest.rb
+++ b/spec/support/examples/failing_manifest.rb
@@ -1,0 +1,5 @@
+shared_examples 'a failing manifest' do
+  it 'should run with errors' do
+    apply_manifest(@manifest, :expect_failures => true)
+  end
+end

--- a/spec/support/examples/idempotent_resource.rb
+++ b/spec/support/examples/idempotent_resource.rb
@@ -1,10 +1,9 @@
 shared_examples 'an idempotent resource' do
   it 'should run without errors' do
-    expect(@result.exit_code).to eq 2
+    apply_manifest(@manifest, :expect_changes => true)
   end
 
   it 'should run a second time without changes' do
-    second_result = apply_manifest(@manifest, acceptable_exit_codes: (0...256))
-    expect(second_result.exit_code).to eq 0
+    apply_manifest(@manifest, :expect_changes => false)
   end
 end

--- a/spec/support/utilities/iis_application_pool.rb
+++ b/spec/support/utilities/iis_application_pool.rb
@@ -1,0 +1,15 @@
+def has_app_pool(pool_name)
+  !(on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {Get-WebAppPoolState -Name #{@pool_name}}\"").stdout =~ /Started/i).nil?
+end
+
+def create_app_pool(pool_name)
+  on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {New-WebAppPool -Name #{@pool_name}}\"") unless has_app_pool(pool_name)
+end
+
+def remove_app_pool(pool_name)
+  on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {Remove-WebAppPool -Name #{@pool_name}}\"") if has_app_pool(pool_name)
+end
+
+def stop_app_pool(pool_name)
+  on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {Stop-WebAppPool -Name #{@pool_name}}\"") if has_app_pool(pool_name)
+end

--- a/spec/types/iis_app_pool_spec.rb
+++ b/spec/types/iis_app_pool_spec.rb
@@ -6,15 +6,15 @@ describe 'iis_application_pool' do
   let :params do
     [
       :name,
-      :state,
-      :managedpipelinemode,
-      :managedruntimeversion,
     ]
   end
 
   let :properties do
     [
       :ensure,
+      :state,
+      :managedpipelinemode,
+      :managedruntimeversion,
     ]
   end
 


### PR DESCRIPTION
This adds the create/update/destroy methods for the iis_application_pool
which handle the name, state, managedpipelinemode, and
managedruntimeversion properties.

This also adds acceptance tests covering iis_application_pool

Included tests:
 - Creation of app pool resource with default params
 - Creation of app pool resource with specified params
 - Creation of app pool resource with invalid params
 - Removal of app pool resource
 - Starting a stopped application pool