### PR TITLE
(MAINT) use beaker-windows to install features in spec_helper_acceptance

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -19,6 +19,7 @@ Gemfile:
   optional:
     ':system_tests':
       - gem: 'beaker-testmode_switcher'
+      - gem: 'beaker-windows'
 MAINTAINERS.md:
   maintainers:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"

--- a/.sync.yml
+++ b/.sync.yml
@@ -17,7 +17,7 @@ appveyor.yml:
       RUBY_VER: 23-x64
 Gemfile:
   optional:
-    ':development':
+    ':system_tests':
       - gem: 'beaker-testmode_switcher'
 MAINTAINERS.md:
   maintainers:

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :system_tests do
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
   gem 'beaker-testmode_switcher'
+  gem 'beaker-windows'
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ group :development do
   gem 'rubocop-rspec', '~> 1.6',            :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
   gem 'pry',                                :require => false
   gem 'json_pure', '<= 2.0.1',              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem 'beaker-testmode_switcher'
 end
 
 group :system_tests do
@@ -71,6 +70,7 @@ group :system_tests do
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem 'beaker-testmode_switcher'
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,6 +2,12 @@ require 'beaker-rspec/helpers/serverspec'
 require 'beaker-rspec/spec_helper'
 require 'beaker/puppet_install_helper'
 require 'beaker/testmode_switcher/dsl'
+require 'beaker-windows'
+
+include BeakerWindows::Path
+include BeakerWindows::Powershell
+include BeakerWindows::Registry
+include BeakerWindows::WindowsFeature
 
 # automatically load any shared examples or contexts
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
@@ -28,16 +34,10 @@ RSpec.configure do |c|
     unless ENV['BEAKER_TESTMODE'] == 'local'
       unless ENV['BEAKER_provision'] == 'no'
         shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
-        # install iis
-        on(agents, puppet("module install puppet/windowsfeature"))
-        pp=<<-EOS
-    $iis_features = ['Web-WebServer','Web-Scripting-Tools']
 
-    windowsfeature { $iis_features:
-      ensure => present,
-    }
-        EOS
-        apply_manifest(pp)
+        # install iis
+        install_windows_feature_on(host, 'Web-WebServer')
+        install_windows_feature_on(host, 'Web-Scripting-Tools')
       end
     end
   end


### PR DESCRIPTION
This removes the dependency on another module (puppet/windowsfeature),
and reduces "pollution" on the SUT.