### PR TITLE
(maint) fix beaker-testmode_switcher gem group

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -17,7 +17,7 @@ appveyor.yml:
       RUBY_VER: 23-x64
 Gemfile:
   optional:
-    ':development':
+    ':system_tests':
       - gem: 'beaker-testmode_switcher'
 MAINTAINERS.md:
   maintainers:

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :system_tests do
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem 'beaker-testmode_switcher'
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])


### PR DESCRIPTION
Don't pull in beaker on the development group.