### PR TITLE
[MODULES-3887] Implement iis_site flush method

### DIFF
--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -29,7 +29,7 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
   end
 
   def flush
-    if exists?
+    if ! @property_hash.empty?
       update
     end
   end

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -22,6 +22,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
     cmd << self.class.ps_script_content('_newwebsite', @resource)
 
+    cmd << self.class.ps_script_content('trysetitemproperty', @resource)
+
     cmd << self.class.ps_script_content('generalproperties', @resource)
 
     cmd << self.class.ps_script_content('logproperties', @resource)
@@ -34,6 +36,29 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
     Puppet.err "Error creating website: #{result[:errormessage]}" unless result[:exitcode] == 0
     Puppet.err "Error creating website: #{result[:errormessage]}" unless result[:errormessage].nil?
+
+    return exists?
+  end
+
+  def update
+    cmd = []
+
+    cmd << self.class.ps_script_content('_setwebsite', @resource)
+
+    cmd << self.class.ps_script_content('trysetitemproperty', @resource)
+
+    cmd << self.class.ps_script_content('generalproperties', @resource)
+
+    cmd << self.class.ps_script_content('logproperties', @resource)
+
+    cmd << self.class.ps_script_content('serviceautostartprovider', @resource)
+
+    inst_cmd = cmd.join
+
+    result = self.class.run(inst_cmd)
+
+    Puppet.err "Error updating website: #{result[:errormessage]}" unless result[:exitcode] == 0
+    Puppet.err "Error updating website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
     return exists?
   end

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -3,7 +3,7 @@
 Get-WebSite | %{
   [PSCustomObject]@{
     name             = [string]$_.Name
-    path             = [string]$_.PhysicalPath
+    physicalpath     = [string]$_.PhysicalPath
     applicationpool  = [string]$_.ApplicationPool
     hostheader       = [string]$_.HostHeader
     state            = [string]$_.State

--- a/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
@@ -21,23 +21,3 @@ $createParams = @{
 # create website
 # dont set applicationpool if it doesnt exist
 New-Website @createParams
-
-function Try-SetItemProperty
-{
-  param($Path, $Name, $Value)
-
-  $existing = Get-ItemProperty -Path $Path -Name $Name -ErrorAction 'Continue'
-
-  if(($existing -eq $null) -or ($existing.Value -ne $Value)){
-
-    try {
-      Set-ItemProperty -Path $Path -Name $Name -Value $Value
-    }catch{
-      throw "Error setting $($Name) to $($Value): $($_)"
-    }
-
-  }else{
-    # NOOP
-  }
-
-}

--- a/lib/puppet/provider/templates/webadministration/_setwebsite.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_setwebsite.ps1.erb
@@ -1,0 +1,4 @@
+$resource = @{
+  name            = '<%= "#{resource[:name]}" %>'
+  ensure          = '<%= "#{resource[:ensure]}" %>'
+}

--- a/lib/puppet/provider/templates/webadministration/logproperties.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/logproperties.ps1.erb
@@ -24,8 +24,8 @@ $logParams = @{
 }
 Try-SetItemProperty @logParams
 
-$logParams.Name  = 'LogFile.LogExtFileFlags'
-$logParams.value = '<%= "#{resource[:logflags]}" %>'
+$logParams.Name  = 'LogFile.logExtFileFlags'
+$logParams.value = "<%= "#{resource[:logflags].is_a?(Array) ? resource[:logflags].join(',') : resource[:logflags]}" %>"
 Try-SetItemProperty @logParams
 <% end -%>
 

--- a/lib/puppet/provider/templates/webadministration/trysetitemproperty.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/trysetitemproperty.ps1.erb
@@ -1,0 +1,18 @@
+function Try-SetItemProperty
+{
+  param($Path, $Name, $Value)
+
+  $existing = Get-ItemProperty -Path $Path -Name $Name -ErrorAction 'Continue'
+
+  if(($existing -eq $null) -or ($existing.Value -ne $Value)){
+
+    try {
+      Set-ItemProperty -Path $Path -Name $Name -Value $Value
+    }catch{
+      throw "Error setting $($Name) to $($Value): $($_)"
+    }
+
+  }else{
+    # NOOP
+  }
+}

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -206,24 +206,25 @@ Puppet::Type.newtype(:iis_site) do
     desc 'Specifies what W3C fields are logged in the IIS log file. This is only
       valid when :logformat is set to W3C. '
     validate do |value|
-      # if value.nil? or value.empty?
-      #   raise ArgumentError, "A non-empty defaultpage must be specified."
-      # end
-      unless value.kind_of?(Array) || value.kind_of?(String)
-        fail("Invalid value '#{value}'. Should be a string")
+      unless value.kind_of?(String)
+        fail("Invalid logflags value '#{value}'. Should be a string")
       end
       unless [
         'Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP',
         'Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent',
         'BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer',
         'ProtocolVersion','Host','HttpSubStatus'
-        ].include?(value)
+      ].include?(value)
         fail("Invalid value '#{value}'. Valid values are Date, Time, ClientIP,
              UserName, SiteName, ComputerName, ServerIP,
              Method, UriStem, UriQuery, HttpStatus, Win32Status, BytesSent,
              BytesRecv, TimeTaken, ServerPort, UserAgent, Cookie, Referer,
              ProtocolVersion, Host, HttpSubStatus")
       end
+    end
+
+    def insync?(is)
+      is.sort == should.sort
     end
   end
 

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -1,0 +1,374 @@
+require 'spec_helper_acceptance'
+
+describe 'iis_site' do
+  before(:all) do
+    # Remove 'Default Web Site' to start from a clean slate
+    remove_all_sites();
+  end
+
+  context 'when configuring a website' do
+    context 'with basic required parameters' do
+      before (:all) do
+        create_path('C:\inetpub\basic')
+        @site_name = "#{SecureRandom.hex(10)}"
+        @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\basic',
+            applicationpool => 'DefaultAppPool',
+          }
+        HERE
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      context 'when puppet resource is run' do
+        before(:all) do
+          @result = on(default, puppet('resource', 'iis_site', @site_name))
+        end
+
+        include_context 'with a puppet resource run'
+        puppet_resource_should_show('ensure', 'started')
+        puppet_resource_should_show('physicalpath', 'C:\inetpub\basic')
+        puppet_resource_should_show('applicationpool', 'DefaultAppPool')
+      end
+
+      after(:all) do
+        remove_all_sites
+      end
+    end
+
+    context 'with all parameters specified' do
+      context 'using W3C log format, logflags and logtruncatesize' do
+        before (:all) do
+          create_path('C:\inetpub\new')
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+            iis_site { '#{@site_name}':
+              ensure               => 'started',
+              applicationpool      => 'DefaultAppPool',
+              enabledprotocols     => 'https',
+              logflags             => ['Date','Time', 'ClientIP', 'UserName'],
+              logformat            => 'W3C',
+              loglocaltimerollover => false,
+              logpath              => 'C:\\inetpub\\logs\\NewLogFiles',
+              logtruncatesize      => 2000000,
+              physicalpath         => 'C:\\inetpub\\new',
+            }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure',               'started')
+          puppet_resource_should_show('applicationpool',      'DefaultAppPool')
+          puppet_resource_should_show('enabledprotocols',     'https')
+          puppet_resource_should_show('logflags',             ['Date', 'Time', 'ClientIP', 'UserName'])
+          puppet_resource_should_show('logformat',            'W3C')
+          puppet_resource_should_show('loglocaltimerollover', 'false')
+          puppet_resource_should_show('logpath',              "C:\\inetpub\\logs\\NewLogFiles")
+          puppet_resource_should_show('logtruncatesize',      '2000000')
+          puppet_resource_should_show('physicalpath',         "C:\\inetpub\\new")
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+
+      context 'using non-W3C log format and logtperiod' do
+        before (:all) do
+          create_path('C:\inetpub\tmp')
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+            iis_site { '#{@site_name}':
+              ensure               => 'started',
+              applicationpool      => 'DefaultAppPool',
+              enabledprotocols     => 'https',
+              logformat            => 'NCSA',
+              loglocaltimerollover => false,
+              logpath              => 'C:\\inetpub\\logs\\NewLogFiles',
+              logperiod            => 'Daily',
+              physicalpath         => 'C:\\inetpub\\new',
+            }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure',               'started')
+          puppet_resource_should_show('applicationpool',      'DefaultAppPool')
+          puppet_resource_should_show('enabledprotocols',     'https')
+          puppet_resource_should_show('logformat',            'NCSA')
+          puppet_resource_should_show('loglocaltimerollover', 'false')
+          puppet_resource_should_show('logpath',              "C:\\inetpub\\logs\\NewLogFiles")
+          puppet_resource_should_show('logperiod',            'Daily')
+          puppet_resource_should_show('physicalpath',         'C:\inetpub\new')
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+    end
+
+    context 'can change site state from' do
+      context 'stopped to started' do
+        before (:all) do
+          create_path('C:\inetpub\tmp')
+          create_site(@site_name, false)
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\tmp',
+            applicationpool => 'DefaultAppPool',
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure', 'started')
+          puppet_resource_should_show('physicalpath', 'C:\inetpub\tmp')
+          puppet_resource_should_show('applicationpool', 'DefaultAppPool')
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+
+      context 'started to stopped' do
+        before (:all) do
+          create_path('C:\inetpub\tmp')
+          create_site(@site_name, true)
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure          => 'stopped',
+            physicalpath    => 'C:\\inetpub\\tmp',
+            applicationpool => 'DefaultAppPool',
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure', 'stopped')
+          puppet_resource_should_show('physicalpath', 'C:\inetpub\tmp')
+          puppet_resource_should_show('applicationpool', 'DefaultAppPool')
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+
+      context 'started to absent' do
+        before (:all) do
+          @site_name = "#{SecureRandom.hex(10)}"
+          create_site(@site_name, true)
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure => 'absent'
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('ensure', 'absent')
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+    end
+
+    context 'with invalid value for' do
+      context 'logformat' do
+        before(:all) do
+          create_path('C:\inetpub\wwwroot')
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\wwwroot',
+            applicationpool => 'DefaultAppPool',
+            logformat       => 'splurge'
+          }
+          HERE
+        end
+
+        it_behaves_like 'a failing manifest'
+      end
+
+      context 'logperiod' do
+        before(:all) do
+          create_path('C:\inetpub\wwwroot')
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\wwwroot',
+            applicationpool => 'DefaultAppPool',
+            logperiod       => 'shouldibeastring? No.'
+          }
+          HERE
+        end
+
+        it_behaves_like 'a failing manifest'
+      end
+
+      after(:all) do
+        remove_all_sites
+      end
+    end
+
+    context 'can changed previously set value' do
+      context 'physicalpath' do
+        before(:all) do
+          create_path('C:\inetpub\new')
+          create_site(@site_name, true)
+          @site_name = "#{SecureRandom.hex(10)}"
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\new',
+            applicationpool => 'DefaultAppPool',
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('physicalpath', 'C:\\inetpub\\new')
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+
+      context 'enabledprotocols' do
+        before(:all) do
+          create_path('C:\inetpub\new')
+          @site_name = "#{SecureRandom.hex(10)}"
+          setup_manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure           => 'started',
+            physicalpath     => 'C:\\inetpub\\new',
+            enabledprotocols => 'http',
+            applicationpool  => 'DefaultAppPool',
+          }
+          HERE
+          apply_manifest(setup_manifest, :catch_failures => true)
+
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure           => 'started',
+            physicalpath     => 'C:\\inetpub\\new',
+            enabledprotocols => 'https',
+            applicationpool  => 'DefaultAppPool',
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('enabledprotocols', 'https')
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+
+      context 'logflags', :focus => true do
+        before(:all) do
+          create_path('C:\inetpub\new')
+          @site_name = "#{SecureRandom.hex(10)}"
+          setup_manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure           => 'started',
+            physicalpath     => 'C:\\inetpub\\new',
+            applicationpool  => 'DefaultAppPool',
+            logformat        => 'W3C',
+            logflags         => ['ClientIP', 'Date', 'HttpStatus']
+          }
+          HERE
+          apply_manifest(setup_manifest, :catch_failures => true)
+
+          @manifest = <<-HERE
+          iis_site { '#{@site_name}':
+            ensure           => 'started',
+            physicalpath     => 'C:\\inetpub\\new',
+            applicationpool  => 'DefaultAppPool',
+            logformat        => 'W3C',
+            logflags         => ['ClientIP', 'Date', 'Method']
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = on(default, puppet('resource', 'iis_site', @site_name))
+          end
+
+          include_context 'with a puppet resource run'
+          puppet_resource_should_show('logflags', ['ClientIP', 'Date', 'Method'])
+        end
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+    end
+  end
+end

--- a/spec/support/examples/idempotent_resource.rb
+++ b/spec/support/examples/idempotent_resource.rb
@@ -1,9 +1,9 @@
 shared_examples 'an idempotent resource' do
   it 'should run without errors' do
-    apply_manifest(@manifest, :expect_changes => true)
+    apply_manifest(@manifest, :catch_failures => true)
   end
 
   it 'should run a second time without changes' do
-    apply_manifest(@manifest, :expect_changes => false)
+    apply_manifest(@manifest, :catch_changes => true)
   end
 end

--- a/spec/support/matchers/puppet_resource_should_show.rb
+++ b/spec/support/matchers/puppet_resource_should_show.rb
@@ -4,8 +4,10 @@ def puppet_resource_should_show(property_name, value)
   it "should report the correct #{property_name} value" do
     regex = if value.nil?
               /(#{property_name})(\s*)(=>)(\s*)/
+            elsif(value.is_a?(Array))
+              /(#{property_name})(\s*)(=>)(\s*)(\[#{value.sort.map!{ |v| "'#{v}'" }.join(', ')}\])/i
             else
-              /(#{property_name})(\s*)(=>)(\s*)('#{value}'|#{value})/i
+              /(#{property_name})(\s*)(=>)(\s*)('#{Regexp.escape(value)}'|#{Regexp.escape(value)})/i
             end
     expect(@result.stdout).to match(regex)
   end

--- a/spec/support/utilities/iis_site.rb
+++ b/spec/support/utilities/iis_site.rb
@@ -1,0 +1,17 @@
+def create_site(name, started, path = 'C:\inetpub\wwwroot')
+  create_path(path)
+  on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {New-Website -Name '#{name}' -PhysicalPath '#{path}'}\"")
+  if(started == true)
+    on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {Start-Website -Name '#{name}'}\"")
+  else
+    on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {Stop-Website -Name '#{name}'}\"")
+  end
+end
+
+def create_path(path)
+  on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& { New-Item -ItemType Directory -Force -Path '#{path}' }\"")
+end
+
+def remove_all_sites
+  on(default, "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -noninteractive -noprofile -executionpolicy bypass -command \"& {Get-Website | Remove-Website}\"")
+end


### PR DESCRIPTION
Within this PR is the implementation of the flush method for the iis_site resource and accompanying acceptance tests to cover this. A number of small fixes were made as required.

**Implement flush for iis_site resource’s web administration provider:**
By reusing a lot of the same powershell code used when creating a new iis_site resource I implemented the `update` method within the iis_site webadministration provider. I abstracted the powershell Try-SetItemProperty to a new template file to avoid repetition.

**Acceptance Tests**
The following tests have been added for the iis_site resource and utility methods implemented to support these tests:
- Create a site with basic params
- Create a site with all params specified
  - Using W3C log format, logflags and logtruncatesize
  - Using NCSA log format and logperiod rather than logtruncatesize
  Change site state
  - From Stopped to Started
  - From Started to Stopped
  - From Started to Absent
- Ensure run fails with invalid params for:
  - logformat param
  - logperiod param
  Ensure can update existing, previously set param:
  - physicalpath param
  - enabledprotocols param
  - logflags param
- Utility methods added:
  - remove_all_sites
  - create_site(name, started, path)
  - create_path(path)

**Fixes:**
- iis_site webadministration provider:
  - Fix errors when no iis_site resources exist
  - Fix typo causing self.instances to return empty physicalpath's
  - In iis_site’s self.to_bool, handle case of empty value returns false in existing regex.
  - In iis_sites’s self.to_bool, return true or false symbols
  - Fix logproperties.ps1 template to correctly set array of flags as a comma-separated string when iis_site is being created or updated

- iis_site type:
  - Overwrite logflags insync? method to deal with differences in ordering of array

- Acceptance Test Support Files:
  - Standardise how we test for idempotency in the `idempotent_resource` shared example, so it is consistent with other modules
  - Escape values passed to `puppet_resource_should_show` to allow validation of path strings containing special characters (e.g. backslashes)