### PR TITLE
(maint) Fix relative path for powershell provider

### DIFF
--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/iis_powershell'
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application Pool provider using the PowerShell WebAdministration module"

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/iis_powershell'
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 # When writing IIS PowerShell code for any of the methods below
 # NEVER EVER use Get-Website without specifying -Name. As the number


### PR DESCRIPTION
This fix ensures that the powershell base provider can be found during a puppet run, regardless of whether its using install puppet or bundle exec