### PR TITLE
(maint) Fix flush/update

### DIFF
--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -29,7 +29,7 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
   end
 
   def flush
-    if ! @property_hash.empty?
+    if exists?
       update
     end
   end

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -22,14 +22,6 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
     cmd << self.class.ps_script_content('_newwebsite', @resource)
 
-    cmd << self.class.ps_script_content('trysetitemproperty', @resource)
-
-    cmd << self.class.ps_script_content('generalproperties', @resource)
-
-    cmd << self.class.ps_script_content('logproperties', @resource)
-
-    cmd << self.class.ps_script_content('serviceautostartprovider', @resource)
-
     inst_cmd = cmd.join
 
     result = self.class.run(inst_cmd)


### PR DESCRIPTION
When flush was implemented for iis_site, the way it determined whether to update the resource was changed to look at  instead of . This broke the way iis_application_pool relied on flush. To fix this, the call to exists? was put back and the iis_site  method was updated to move the property sets to update .