### PR TITLE
(MODULES-4370) Add PowerShell 2.0 and IIS 7.5 support

### DIFF
--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application Pool provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['8.0', '8.5']
+  confine    :iis_version     => ['7.5','8.0', '8.5']
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 
@@ -61,11 +61,11 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
   def self.instances
     inst_cmd = ps_script_content('_getapppools', @resource)
     result   = run(inst_cmd)
-    text     = result[:stdout]
-    return [] if text.nil?
+    return [] if result.nil?
 
-    pool_json = JSON.parse(text)
-    pool_json = [pool_json] if pool_json.is_a?(Hash)
+    pool_json = self.parse_json_result(result[:stdout])
+    return [] if pool_json.nil?
+
     pool_json.collect do |pool|
       pool_hash = {}
 

--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -35,6 +35,16 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
   end
 
   def self.run(command, check = false)
+    if self.ps_major_version == 2
+      # - PowerShell 2.0 does not support autoload of modules therefore we must explicitly add the WebAdministration module
+      # - Must change the current location to the be the IIS: provider
+      # - Add the ConvertTo-JSON command support
+      command = "Import-Module WebAdministration -ErrorAction Stop\n" +
+                "cd iis:\n" +
+                ps_script_content('json_1.7', @resource) + "\n" +
+                command
+    end
+
     Puppet.debug("COMMAND: #{command}")
     result = ps_manager.execute(command)
 
@@ -102,6 +112,35 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
       version = nil
     end
     version
+  end
+
+  def self.parse_json_result(raw)
+    return nil if raw.nil?
+    # Unfortunately PowerShell tends to automatically insert CRLF characters mid-string (Console Width)
+    # However as we're using JSON which does not use Line Endings for termination, we can safely strip them
+    raw.gsub!("\n",'')
+    raw.gsub!("\r",'')
+
+    result = JSON.parse(raw)
+    return nil if result.nil?
+
+    # The JSON conversion for PowerShell 2.0 always creates a root HashTable with a single key of 'Objects'
+    # whereas under PowerShell 3.0+ this is not the case.  Detect the PowerShell 2.0 style and render it back
+    # into a PowerShell 3.0+ format.
+    if result.is_a?(Hash) && result.keys[0] == 'Objects'
+      # If only a single object is returned then the result is Hash with a single 'Object' key
+      # if multiple objects are returned then the result is an array of Hashes
+      if result['Objects'].is_a?(Hash) && result['Objects'].keys[0] == 'Object'
+        return [result['Objects']['Object']]
+      elsif result['Objects'].is_a?(Array)
+        return result['Objects']
+      else
+        raise "Unable to determine the JSON encoding from PowerShell 2.0"
+      end
+    end
+
+    # Always return an Array type
+    result.is_a?(Array) ? result : [result]
   end
 
   def self.ps_script_content(template, resource)

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -9,7 +9,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['8.0','8.5']
+  confine    :iis_version     => ['7.5','8.0','8.5']
   confine    :operatingsystem => [:windows ]
   defaultfor :operatingsystem => :windows
 
@@ -126,13 +126,11 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
   def self.instances
     inst_cmd = ps_script_content('_getwebsites', @resource)
     result   = run(inst_cmd)
+    return [] if result.nil?
 
-    return [] if result.nil? || result[:stdout].nil?
-
-    site_json = JSON.parse(result[:stdout])
+    site_json = self.parse_json_result(result[:stdout])
     return [] if site_json.nil?
 
-    site_json = [site_json] if site_json.is_a?(Hash)
     return site_json.collect do |site|
       site_hash = {}
 

--- a/lib/puppet/provider/templates/iisadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/iisadministration/_getwebsites.ps1.erb
@@ -1,5 +1,5 @@
 Get-IISSite | %{
-  [PSCustomObject]@{
+  New-Object -TypeName PSObject -Property @{
     name             = [string]$_.Name
     path             = [string]$_.PhysicalPath
     applicationpool  = [string]$_.ApplicationPool
@@ -8,7 +8,7 @@ Get-IISSite | %{
     serverautostart  = [string]$_.serverautostart
     enabledprotocols = [string]$_.enabledprotocols
     bindings         = @($_.Bindings.Collection | %{
-      [PSCustomObject]@{
+      New-Object -TypeName PSObject -Property @{
         protocol             = [string]$_.protocol
         bindinginformation   = [string]$_.bindingInformation
         sslflags             = [string]$_.sslFlags

--- a/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
@@ -1,7 +1,5 @@
-# TODO: this is JSON, PS v2 doesnt support it
-# PSCustomObject isnt present in v2
 Get-WebConfiguration -Filter '/system.applicationHost/applicationPools/add' | % {
-  [PSCustomObject]@{
+  New-Object -TypeName PSObject -Property @{
     name  = [string]$_.Name
     state = [string]$_.State
     managedpipelinemode = [string]$_.ManagedPipelineMode

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -1,7 +1,5 @@
-# TODO: this is JSON, PS v2 doesnt support it
-# PSCustomObject isnt present in v2
 Get-WebSite | %{
-  [PSCustomObject]@{
+  New-Object -TypeName PSObject -Property @{
     name             = [string]$_.Name
     physicalpath     = [string]$_.PhysicalPath
     applicationpool  = [string]$_.ApplicationPool
@@ -10,7 +8,7 @@ Get-WebSite | %{
     serverautostart  = [string]$_.serverautostart
     enabledprotocols = [string]$_.enabledprotocols
     bindings         = @($_.Bindings.Collection | %{
-      [PSCustomObject]@{
+      New-Object -TypeName PSObject -Property @{
         protocol             = [string]$_.protocol
         bindinginformation   = [string]$_.bindingInformation
         sslflags             = [int]$_.sslFlags

--- a/lib/puppet/provider/templates/webadministration/json_1.7.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/json_1.7.ps1.erb
@@ -1,0 +1,633 @@
+#requires -version 2.0
+# Version History:
+# v 0.5 - First Public version
+# v 1.0 - Made ConvertFrom-Json work with arbitrary JSON 
+#       - switched to xsl style sheets for ConvertTo-JSON
+# v 1.1 - Changed ConvertFrom-Json to handle single item results
+# v 1.2 - CodeSigned to make a fellow geek happy
+# v 1.3 - Changed ConvertFrom-Json to handle zero item results (I hope)
+# v 1.4 - Added -File parmeter set to ConvertFrom-Json
+#       - Cleaned up some error messages
+# v 1.5 - Corrected handling of arrays
+# v 1.6 - Corrected pipeline binding on ConvertFrom-Json
+# v 1.7 - Added a New-Json which converts simple hashtables...
+#
+#  There is no help (yet) because I keep forgetting that I haven't written help yet.
+#  Full RoundTrip capability:
+#
+#  > ls | ConvertTo-Json | ConvertFrom-Json
+#  > ps | ConvertTo-Json | Convert-JsonToXml | Convert-XmlToJson | convertFrom-Json
+#
+#  You may frequently want to use the DEPTH or NoTypeInformation parameters:
+#
+#  > ConvertTo-Json -Depth 2 -NoTypeInformation
+#
+#  But then you have to specify the type when you reimport (and you can't do that for deep objects).  
+#  This problem also occurs if you convert the result of a SELECT statement (ie: PSCustomObject).
+#  For Example:
+#
+#  > PS | Select PM, WS, CPU, ID, ProcessName |
+#  >> ConvertTo-json -NoType |
+#  >> convertfrom-json -Type System.Diagnostics.Process
+#
+#  However, you *can* use PSOjbect as your type when re-importing:
+#
+#  > $Json = Get-Process | 
+#  >> Select PM, WS, CPU, ID, ProcessName, @{n="SnapshotTime";e={Get-Date}} | 
+#  >> ConvertTo-Json -NoType 
+#  
+#  > $Json | ConvertFrom-json -Type PSObject
+
+
+Add-Type -AssemblyName System.ServiceModel.Web, System.Runtime.Serialization
+$utf8 = [System.Text.Encoding]::UTF8
+
+function Write-Stream {
+PARAM(
+   [Parameter(Position=0)]$stream,
+   [Parameter(ValueFromPipeline=$true)]$string
+)
+PROCESS {
+  $bytes = $utf8.GetBytes($string)
+  $stream.Write( $bytes, 0, $bytes.Length )
+}  
+}
+
+
+function Read-Stream {
+PARAM(
+   [Parameter(Position=0,ValueFromPipeline=$true)]$Stream
+)
+process {
+   $bytes = $Stream.ToArray()
+   [System.Text.Encoding]::UTF8.GetString($bytes,0,$bytes.Length)
+}}
+
+
+function Convert-JsonToXml {
+PARAM([Parameter(ValueFromPipeline=$true)][string[]]$json)
+BEGIN { 
+   $mStream = New-Object System.IO.MemoryStream 
+}
+PROCESS {
+   $json | Write-Stream -Stream $mStream
+}
+END {
+   $mStream.Position = 0
+   try
+   {
+      $jsonReader = [System.Runtime.Serialization.Json.JsonReaderWriterFactory]::CreateJsonReader($mStream,[System.Xml.XmlDictionaryReaderQuotas]::Max)
+      $xml = New-Object Xml.XmlDocument
+      $xml.Load($jsonReader)
+      $xml
+   }
+   finally
+   {
+      $jsonReader.Close()
+      $mStream.Dispose()
+   }
+}
+}
+ 
+function Convert-XmlToJson {
+PARAM([Parameter(ValueFromPipeline=$true)][Xml]$xml)
+PROCESS {
+   $mStream = New-Object System.IO.MemoryStream
+   $jsonWriter = [System.Runtime.Serialization.Json.JsonReaderWriterFactory]::CreateJsonWriter($mStream)
+   try
+   {
+     $xml.Save($jsonWriter)
+     $bytes = $mStream.ToArray()
+     [System.Text.Encoding]::UTF8.GetString($bytes,0,$bytes.Length)
+   }
+   finally
+   {
+     $jsonWriter.Close()
+     $mStream.Dispose()
+   }
+}
+}
+
+function New-Json {
+[CmdletBinding()]
+param([Parameter(ValueFromPipeline=$true)][HashTable]$InputObject) 
+begin { 
+   $ser = @{}
+   $jsona = @()
+}
+process {
+   $jsoni = 
+   foreach($input in $InputObject.GetEnumerator() | Where { $_.Value } ) {
+      if($input.Value -is [Hashtable]) {
+         '"'+$input.Key+'": ' + (New-JSon $input.Value)
+      } else {
+         $type = $input.Value.GetType()
+         if(!$Ser.ContainsKey($Type)) {
+            $Ser.($Type) = New-Object System.Runtime.Serialization.Json.DataContractJsonSerializer $type
+         }
+         $stream = New-Object System.IO.MemoryStream
+         $Ser.($Type).WriteObject( $stream, $Input.Value )
+         '"'+$input.Key+'": ' + (Read-Stream $stream)
+      }
+   }
+
+   $jsona += "{`n" +($jsoni -join ",`n")+ "`n}"
+}
+end { 
+   if($jsona.Count -gt 1) {
+      "[$($jsona -join ",`n")]" 
+   } else {
+      $jsona
+   }
+}}
+
+
+## Rather than rewriting ConvertTo-Xml ...
+Function ConvertTo-Json {
+[CmdletBinding()]
+Param(
+   [Parameter(Mandatory=$true,Position=1,ValueFromPipeline=$true)]$InputObject
+,
+   [Parameter(Mandatory=$false)][Int]$Depth=1
+,
+   [Switch]$NoTypeInformation
+)
+END { 
+   ## You must output ALL the input at once 
+   ## ConvertTo-Xml outputs differently if you just have one, so your results would be different
+   $input | ConvertTo-Xml -Depth:$Depth -NoTypeInformation:$NoTypeInformation -As Document | Convert-CliXmlToJson
+}
+}
+
+Function Convert-CliXmlToJson {
+PARAM(
+   [Parameter(ValueFromPipeline=$true)][Xml.XmlNode]$xml
+)
+BEGIN {
+   $xmlToJsonXsl = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<!--
+  CliXmlToJson.xsl
+
+  Copyright (c) 2006,2008 Doeke Zanstra
+  Copyright (c) 2009 Joel Bennett
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this 
+  list of conditions and the following disclaimer. Redistributions in binary 
+  form must reproduce the above copyright notice, this list of conditions and the 
+  following disclaimer in the documentation and/or other materials provided with 
+  the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+  THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+  <xsl:output indent="no" omit-xml-declaration="yes" method="text" encoding="UTF-8" media-type="text/x-json"/>
+	<xsl:strip-space elements="*"/>
+  <!--contant-->
+  <xsl:variable name="d">0123456789</xsl:variable>
+
+  <!-- ignore document text -->
+  <xsl:template match="text()[preceding-sibling::node() or following-sibling::node()]"/>
+
+  <!-- string -->
+  <xsl:template match="text()">
+    <xsl:call-template name="escape-string">
+      <xsl:with-param name="s" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+  
+  <!-- Main template for escaping strings; used by above template and for object-properties 
+       Responsibilities: placed quotes around string, and chain up to next filter, escape-bs-string -->
+  <xsl:template name="escape-string">
+    <xsl:param name="s"/>
+    <xsl:text>"</xsl:text>
+    <xsl:call-template name="escape-bs-string">
+      <xsl:with-param name="s" select="`$s"/>
+    </xsl:call-template>
+    <xsl:text>"</xsl:text>
+  </xsl:template>
+  
+  <!-- Escape the backslash (\) before everything else. -->
+  <xsl:template name="escape-bs-string">
+    <xsl:param name="s"/>
+    <xsl:choose>
+      <xsl:when test="contains(`$s,'\')">
+        <xsl:call-template name="escape-quot-string">
+          <xsl:with-param name="s" select="concat(substring-before(`$s,'\'),'\\')"/>
+        </xsl:call-template>
+        <xsl:call-template name="escape-bs-string">
+          <xsl:with-param name="s" select="substring-after(`$s,'\')"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="escape-quot-string">
+          <xsl:with-param name="s" select="`$s"/>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <!-- Escape the double quote ("). -->
+  <xsl:template name="escape-quot-string">
+    <xsl:param name="s"/>
+    <xsl:choose>
+      <xsl:when test="contains(`$s,'&quot;')">
+        <xsl:call-template name="encode-string">
+          <xsl:with-param name="s" select="concat(substring-before(`$s,'&quot;'),'\&quot;')"/>
+        </xsl:call-template>
+        <xsl:call-template name="escape-quot-string">
+          <xsl:with-param name="s" select="substring-after(`$s,'&quot;')"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="encode-string">
+          <xsl:with-param name="s" select="`$s"/>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <!-- Replace tab, line feed and/or carriage return by its matching escape code. Can't escape backslash
+       or double quote here, because they don't replace characters (&#x0; becomes \t), but they prefix 
+       characters (\ becomes \\). Besides, backslash should be seperate anyway, because it should be 
+       processed first. This function can't do that. -->
+  <xsl:template name="encode-string">
+    <xsl:param name="s"/>
+    <xsl:choose>
+      <!-- tab -->
+      <xsl:when test="contains(`$s,'&#x9;')">
+        <xsl:call-template name="encode-string">
+          <xsl:with-param name="s" select="concat(substring-before(`$s,'&#x9;'),'\t',substring-after(`$s,'&#x9;'))"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- line feed -->
+      <xsl:when test="contains(`$s,'&#xA;')">
+        <xsl:call-template name="encode-string">
+          <xsl:with-param name="s" select="concat(substring-before(`$s,'&#xA;'),'\n',substring-after(`$s,'&#xA;'))"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- carriage return -->
+      <xsl:when test="contains(`$s,'&#xD;')">
+        <xsl:call-template name="encode-string">
+          <xsl:with-param name="s" select="concat(substring-before(`$s,'&#xD;'),'\r',substring-after(`$s,'&#xD;'))"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise><xsl:value-of select="`$s"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- number (no support for javascript mantise) -->
+  <xsl:template match="text()[not(string(number())='NaN' or
+                       (starts-with(.,'0' ) and . != '0'))]">
+    <xsl:value-of select="."/>
+  </xsl:template>
+
+  <!-- boolean, case-insensitive -->
+  <xsl:template match="text()[translate(.,'TRUE','true')='true']">true</xsl:template>
+  <xsl:template match="text()[translate(.,'FALSE','false')='false']">false</xsl:template>
+
+  <!-- root object(s) -->
+  <xsl:template match="*" name="base">
+    <xsl:if test="not(preceding-sibling::*)">
+      <xsl:choose>
+        <xsl:when test="count(../*)>1"><xsl:text>[</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>{</xsl:text></xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+    <xsl:call-template name="escape-string">
+      <xsl:with-param name="s" select="name()"/>
+    </xsl:call-template>
+    <xsl:text>:</xsl:text>
+    <!-- check type of node -->
+    <xsl:choose>
+      <!-- null nodes -->
+      <xsl:when test="count(child::node())=0">null</xsl:when>
+      <!-- other nodes -->
+      <xsl:otherwise>
+      	<xsl:apply-templates select="child::node()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+    <!-- end of type check -->
+    <xsl:if test="following-sibling::*">,</xsl:if>
+    <xsl:if test="not(following-sibling::*)">
+      <xsl:choose>
+        <xsl:when test="count(../*)>1"><xsl:text>]</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>}</xsl:text></xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- properties of objects -->
+  <xsl:template match="*[count(../*[name(../*)=name(.)])=count(../*) and count(../*)&gt;1]">
+    <xsl:variable name="inArray" select="translate(local-name(),'OBJECT','object')='object' or ../@Type[starts-with(.,'System.Collections') or contains(.,'[]') or (contains(.,'[') and contains(.,']'))]"/>
+    <xsl:if test="not(preceding-sibling::*)">
+       <xsl:choose>
+         <xsl:when test="`$inArray"><xsl:text>[</xsl:text></xsl:when>
+         <xsl:otherwise>
+            <xsl:text>{</xsl:text>
+            <xsl:if test="../@Type">
+               <xsl:text>"__type":</xsl:text>      
+               <xsl:call-template name="escape-string">
+                 <xsl:with-param name="s" select="../@Type"/>
+               </xsl:call-template>
+               <xsl:text>,</xsl:text>      
+             </xsl:if>
+         </xsl:otherwise>
+       </xsl:choose>
+    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="not(child::node())">
+        <xsl:call-template name="escape-string">
+          <xsl:with-param name="s" select="@Name"/>
+        </xsl:call-template>
+        <xsl:text>:null</xsl:text>
+      </xsl:when>
+      <xsl:when test="`$inArray">
+        <xsl:apply-templates select="child::node()"/>
+      </xsl:when>
+      <!--
+      <xsl:when test="not(@Name) and not(@Type)">
+        <xsl:call-template name="escape-string">
+          <xsl:with-param name="s" select="local-name()"/>
+        </xsl:call-template>
+        <xsl:text>:</xsl:text>      
+        <xsl:apply-templates select="child::node()"/>
+      </xsl:when>
+      -->
+      <xsl:when test="not(@Name)">
+        <xsl:call-template name="escape-string">
+          <xsl:with-param name="s" select="local-name()"/>
+        </xsl:call-template>
+        <xsl:text>:</xsl:text>      
+        <xsl:apply-templates select="child::node()"/>
+      </xsl:when> 
+      <xsl:otherwise>
+        <xsl:call-template name="escape-string">
+          <xsl:with-param name="s" select="@Name"/>
+        </xsl:call-template>
+        <xsl:text>:</xsl:text>
+        <xsl:apply-templates select="child::node()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:if test="following-sibling::*">,</xsl:if>
+    <xsl:if test="not(following-sibling::*)">       
+      <xsl:choose>
+        <xsl:when test="`$inArray"><xsl:text>]</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>}</xsl:text></xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+  
+  
+  <!-- convert root element to an anonymous container -->
+  <xsl:template match="/">
+    <xsl:apply-templates select="node()"/>
+  </xsl:template>    
+</xsl:stylesheet>
+"@
+}
+PROCESS {
+   if(Get-Member -InputObject $xml -Name root) {
+      Write-Verbose "Ripping to Objects"
+      $xml = $xml.root.Objects
+   } else {
+      Write-Verbose "Was already Objects"
+   }
+   Convert-Xml -Xml $xml -Xsl $xmlToJsonXsl
+}
+}
+
+Function ConvertFrom-Xml {
+   [CmdletBinding(DefaultParameterSetName="AutoType")]
+   PARAM(
+      [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1)]
+      [Xml.XmlNode]
+      $xml
+      ,
+      [Parameter(Mandatory=$true,ParameterSetName="ManualType")]
+      [Type]$Type
+      ,
+      [Switch]$ForceType
+   )
+   PROCESS{ 
+      if(Get-Member -InputObject $xml -Name root) {
+         return $xml.root.Objects | ConvertFrom-Xml
+      } elseif(Get-Member -InputObject $xml -Name Objects) {
+         return $xml.Objects | ConvertFrom-Xml
+      }
+      $propbag = @{}
+      foreach($name in Get-Member -InputObject $xml -MemberType Properties | Where-Object{$_.Name -notmatch "^__|type"} | Select-Object -ExpandProperty name) {
+         Write-Verbose "$Name Type: $($xml.$Name.type)"
+         $propbag."$Name" = Convert-Properties $xml."$name"
+      }
+      if(!$Type -and $xml.HasAttribute("__type")) { $Type = $xml.__Type }
+      if($ForceType -and $Type) {
+         try {
+            $output = New-Object $Type -Property $propbag
+         } catch {
+            $output = New-Object PSObject -Property $propbag
+            $output.PsTypeNames.Insert(0, $xml.__type)
+         }
+      } else {
+         $output = New-Object PSObject -Property $propbag
+         if($Type) {
+            $output.PsTypeNames.Insert(0, $Type)
+         }
+      }
+      Write-Output $output
+   }
+}
+
+Function Convert-Properties {
+param($InputObject)
+   switch( $InputObject.type ) {
+      "object" {
+         return (ConvertFrom-Xml -Xml $InputObject)
+         break
+      } 
+      "string" {
+         $MightBeADate = $InputObject.get_InnerText() -as [DateTime]
+         ## Strings that are actually dates (*grumble* JSON is crap)               
+         if($MightBeADate -and $propbag."$Name" -eq $MightBeADate.ToString("G")) {
+            return $MightBeADate
+         } else {
+            return $InputObject.get_InnerText()
+         }
+         break
+      }
+      "number" {
+         $number = $InputObject.get_InnerText()
+         if($number -eq ($number -as [int])) {
+            return $number -as [int]
+         } elseif($number -eq ($number -as [double])) {
+            return $number -as [double]
+         } else {
+            return $number -as [decimal]
+         }
+         break
+      }
+      "boolean" {
+         return [bool]::parse($InputObject.get_InnerText())
+      }
+      "null" {
+         return $null
+      }
+      "array" {
+         [object[]]$Items = $( foreach( $item in $InputObject.GetEnumerator() ) {
+            Convert-Properties $item
+         } )
+         return $Items
+      }
+      default {
+         return $InputObject
+         break
+      }
+   }
+
+}
+
+
+
+Function ConvertFrom-Json {
+   [CmdletBinding(DefaultParameterSetName="StringInput")]
+PARAM(
+   [Parameter(Mandatory=$true,Position=1,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true,ParameterSetName="File")]
+   [Alias("PSPath")]
+   [string]$File
+,
+   [Parameter(ValueFromPipeline=$true,Mandatory=$true,Position=1,ParameterSetName="StringInput")]
+   [string]$InputObject
+,
+   [Parameter(Mandatory=$true)]
+   [Type]$Type
+   ,
+   [Switch]$ForceType
+)
+BEGIN {
+   [bool]$AsParameter = $PSBoundParameters.ContainsKey("File") -or $PSBoundParameters.ContainsKey("InputObject") 
+}
+PROCESS {
+   if($PSCmdlet.ParameterSetName -eq "File") {
+      [string]$InputObject = @(Get-Content $File) -Join "`n"
+      $null = $PSBoundParameters.Remove("File")
+   }
+   else 
+   {
+      $null = $PSBoundParameters.Remove("InputObject")
+   }
+   [Xml.XmlElement]$xml = (Convert-JsonToXml $InputObject).Root
+   if($xml) {
+      if($xml.Objects) {
+         $xml.Objects.Item.GetEnumerator() | ConvertFrom-Xml @PSBoundParameters
+      }elseif($xml.Item -and $xml.Item -isnot [System.Management.Automation.PSParameterizedProperty]) {
+         $xml.Item | ConvertFrom-Xml @PSBoundParameters
+      }else {
+         $xml | ConvertFrom-Xml @PSBoundParameters
+      }
+   } else {
+      Write-Error "Failed to parse JSON with JsonReader"
+   }
+}
+}
+
+#########
+### The JSON library is dependent on Convert-Xml from my Xml script module
+
+function Convert-Node {
+param(
+[Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+[System.Xml.XmlReader]$XmlReader,
+[Parameter(Position=1,Mandatory=$true,ValueFromPipeline=$false)]
+[System.Xml.Xsl.XslCompiledTransform]$StyleSheet
+) 
+PROCESS {
+   $output = New-Object IO.StringWriter
+   $StyleSheet.Transform( $XmlReader, $null, $output )
+   Write-Output $output.ToString()
+}
+}
+   
+function Convert-Xml {
+#.Synopsis
+#  The Convert-XML function lets you use Xslt to transform XML strings and documents.
+#.Description
+#.Parameter Content
+#  Specifies a string that contains the XML to search. You can also pipe strings to Select-XML.
+#.Parameter Namespace
+#   Specifies a hash table of the namespaces used in the XML. Use the format @{<namespaceName> = <namespaceUri>}.
+#.Parameter Path
+#   Specifies the path and file names of the XML files to search.  Wildcards are permitted.
+#.Parameter Xml
+#  Specifies one or more XML nodes to search.
+#.Parameter Xsl
+#  Specifies an Xml StyleSheet to transform with...
+[CmdletBinding(DefaultParameterSetName="Xml")]
+PARAM(
+   [Parameter(Position=1,ParameterSetName="Path",Mandatory=$true,ValueFromPipelineByPropertyName=$true)]
+   [ValidateNotNullOrEmpty()]
+   [Alias("PSPath")]
+   [String[]]$Path
+,
+   [Parameter(Position=1,ParameterSetName="Xml",Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+   [ValidateNotNullOrEmpty()]
+   [Alias("Node")]
+   [System.Xml.XmlNode[]]$Xml
+,
+   [Parameter(ParameterSetName="Content",Mandatory=$true,ValueFromPipeline=$true)]
+   [ValidateNotNullOrEmpty()]
+   [String[]]$Content
+,
+   [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$false)]
+   [ValidateNotNullOrEmpty()]
+   [Alias("StyleSheet")]
+   [String[]]$Xslt
+)
+BEGIN { 
+   $StyleSheet = New-Object System.Xml.Xsl.XslCompiledTransform
+   if(Test-Path @($Xslt)[0] -ErrorAction 0) { 
+      Write-Verbose "Loading Stylesheet from $(Resolve-Path @($Xslt)[0])"
+      $StyleSheet.Load( (Resolve-Path @($Xslt)[0]) )
+   } else {
+      Write-Verbose "$Xslt"
+      $StyleSheet.Load(([System.Xml.XmlReader]::Create((New-Object System.IO.StringReader ($Xslt -join "`n")))))
+   }
+   [Text.StringBuilder]$XmlContent = [String]::Empty 
+}
+PROCESS {
+   switch($PSCmdlet.ParameterSetName) {
+      "Content" {
+         $null = $XmlContent.AppendLine( $Content -Join "`n" )
+      }
+      "Path" {
+         foreach($file in Get-ChildItem $Path) {
+            Convert-Node -Xml ([System.Xml.XmlReader]::Create((Resolve-Path $file))) $StyleSheet
+         }
+      }
+      "Xml" {
+         foreach($node in $Xml) {
+            Convert-Node -Xml (New-Object Xml.XmlNodeReader $node) $StyleSheet
+         }
+      }
+   }
+}
+END {
+   if($PSCmdlet.ParameterSetName -eq "Content") {
+      [Xml]$Xml = $XmlContent.ToString()
+      Convert-Node -Xml $Xml $StyleSheet
+   }
+}
+}

--- a/lib/puppet/provider/templates/webadministration/json_1.7.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/json_1.7.ps1.erb
@@ -149,12 +149,12 @@ Param(
    [Parameter(Mandatory=$true,Position=1,ValueFromPipeline=$true)]$InputObject
 ,
    [Parameter(Mandatory=$false)][Int]$Depth=1
-,
-   [Switch]$NoTypeInformation
 )
 END { 
    ## You must output ALL the input at once 
    ## ConvertTo-Xml outputs differently if you just have one, so your results would be different
+   $NoTypeInformation = $true
+
    $input | ConvertTo-Xml -Depth:$Depth -NoTypeInformation:$NoTypeInformation -As Document | Convert-CliXmlToJson
 }
 }

--- a/spec/integration/puppet/provider/iis_powershell_spec.rb
+++ b/spec/integration/puppet/provider/iis_powershell_spec.rb
@@ -1,0 +1,94 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet/provider/iis_powershell'
+
+describe Puppet::Provider::IIS_PowerShell, :if => Puppet::Util::Platform.windows? do
+  let (:subject) { Puppet::Provider::IIS_PowerShell }
+
+  describe "when powershell is installed" do
+
+    describe "when powershell version is greater than three" do
+
+      it "should detect a powershell version" do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+
+        version = subject.powershell_version
+
+        expect(version).to eq '5.0.10514.6'
+      end
+
+      it "should call the powershell three registry path" do
+        reg_key = mock('bob')
+        reg_key.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).yields(reg_key).once
+
+        subject.powershell_version
+      end
+
+      it "should not call powershell one registry path" do
+        reg_key = mock('bob')
+        reg_key.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).yields(reg_key)
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).times(0)
+
+        subject.powershell_version
+      end
+
+      it 'should return the major version of powershell' do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('5.0.10514.6')
+
+        version = subject.ps_major_version(true)
+
+        expect(version).to eq 5
+      end
+    end
+
+    describe "when powershell version is less than three" do
+      it "should detect a powershell version" do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('2.0')
+
+        version = subject.powershell_version
+
+        expect(version).to eq '2.0'
+      end
+
+      it "should call powershell one registry path" do
+        reg_key = mock('bob')
+        reg_key.expects(:[]).with('PowerShellVersion').returns('2.0')
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+        Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).yields(reg_key).once
+
+        version = subject.powershell_version
+
+        expect(version).to eq '2.0'
+      end
+
+      it 'should return the major version of powershell' do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('2.0')
+        version = subject.ps_major_version(true)
+
+        expect(version).to eq 2
+      end
+    end
+  end
+
+  describe "when powershell is not installed" do
+    before do
+      Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+      Win32::Registry.any_instance.expects(:open).with('SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', Win32::Registry::KEY_READ | 0x100).raises(Win32::Registry::Error.new(2), 'nope').once
+    end
+
+    it "should return nil and not throw" do
+      version = subject.powershell_version
+
+      expect(version).to eq nil
+    end
+
+    it 'should return the major version as nil and not throw' do
+      version = subject.ps_major_version(true)
+
+      expect(version).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
Previously the module could not determine what scripts to execute as the
PowerShell version was unknown.  This commit adds a PowerShell version class and
method on the base IIS Provider to detect and cache the major PowerShell version.
This will be used in later methods to appropriately execute the correct scripts.

The IIS module uses JSON as the data transport between PowerShell and ruby.
However PowerShell 2.0 does not have a native JSON serializer.  This commit adds
the required PowerShell script to convert an object into a JSON string, and is
compatible with PowerShell 2.0.

Previously the module would not function on Windows 2008R2 which uses PowerShell
2.0 and IIS 7.5 by default.  This commit adds support by the following:

- Changes the usages of `[PSCustomObject]` to `New-Object ...` which will create
  appropriate object classes in PowerShell 2.0 and above.  Note that these are
  still objects of type PSCustomObject
- Added IIS version 7.5 to the confinement for the providers
- Added a JSON preparser as there are differences between the JSON generated by
  PowerShell 2.0 and 3.0+.  This method converts PowerShell 2.0 JSON objects
  into the 3.0+ equivalent
- Added a standard command header `add_powershell2_support` to all PowerShell
  invocations

Previously the type information for an object was being inserted into the JSON
documents.  While this does not break any existing functionality, future changes
to the module would have to deal with the extra information.  This commit sets
the NoTypeInformation to false and thereby stops all type information being
created.