### PR TITLE
(maint) Remove pinning of beaker-module_install_helper to github fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ group :system_tests do
   gem 'beaker-pe',                                                               :require => false
   gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'])                
   gem 'beaker-puppet_install_helper',                                            :require => false
-  gem 'beaker-module_install_helper', :git => 'https://github.com/wilson208/beaker-module_install_helper', :branch => 'MODULES-4312'
+  gem 'beaker-module_install_helper',                                            :require => false
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')


### PR DESCRIPTION
This change was left in in PR #23, when some changes were being made to beaker-module_install_helper to support #23. The changes to beaker-module_install_helper have now been released to rubygems and this pinning to my fork is no longer necessary.