### PR TITLE
(maint) Add rototiller to .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,6 +13,7 @@ Gemfile:
   optional:
     ':system_tests':
       - gem: 'beaker-testmode_switcher'
+      - gem: 'rototiller'
 MAINTAINERS.md:
   maintainers:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"


### PR DESCRIPTION
This will mean that the reference to rototiller which was added to the gemfile in PR #23 will not be overidden on the next modulesync run