### PR TITLE
(MODULES-3832) Update PowerShell Manager Code

### DIFF
--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -47,7 +47,7 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
     end
 
     Puppet.debug("COMMAND: #{command}")
-    result = ps_manager.execute(command)
+    result = ps_manager.execute(command, nil, nil)
 
     stdout      = result[:stdout]
     stderr      = result[:stderr]

--- a/lib/puppet_x/puppetlabs/iis/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/iis/powershell_manager.rb
@@ -12,7 +12,15 @@ module PuppetX
       @@instances = {}
 
       def self.instance(cmd)
-        @@instances[:cmd] ||= PowerShellManager.new(cmd)
+        manager = @@instances[cmd]
+
+        if manager.nil? || !manager.alive?
+          # ignore any errors trying to tear down this unusable instance
+          manager.exit if manager rescue nil
+          @@instances[cmd] = PowerShellManager.new(cmd)
+        end
+
+         @@instances[cmd]
       end
 
       def self.win32console_enabled?
@@ -26,6 +34,8 @@ module PuppetX
       end
 
       def initialize(cmd)
+        @usable = true
+        # @stderr should never be written to as PowerShell host redirects output
         @stdin, @stdout, @stderr, @ps_process = Open3.popen3(cmd)
 
         Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
@@ -41,13 +51,29 @@ module PuppetX
         at_exit { exit }
       end
 
-      def execute(powershell_code, timeout_ms = 300 * 1000)
+      def alive?
+        # powershell process running
+        @ps_process.alive? &&
+          # explicitly set during a read / write failure, like broken pipe EPIPE
+          @usable &&
+          # an explicit failure state might not have been hit, but IO may be closed
+          self.class.is_stream_valid?(@stdin) &&
+          self.class.is_stream_valid?(@stdout) &&
+          self.class.is_stream_valid?(@stderr)
+      end
+
+      def execute(powershell_code, timeout_ms = nil, working_dir = nil)
         output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
         output_ready_event = self.class.create_event(output_ready_event_name)
 
-        code = make_ps_code(powershell_code, output_ready_event_name, timeout_ms)
+        code = make_ps_code(powershell_code, output_ready_event_name, timeout_ms, working_dir)
 
+        # err is drained stderr pipe (not captured by redirection inside PS)
+        # or during a failure, a Ruby callstack array
         out, err = exec_read_result(code, output_ready_event)
+
+        # an error was caught during execution that has invalidated any results
+        return { :exitcode => -1, :stderr => err } if !@usable && out.nil?
 
         # Powershell adds in newline characters as it tries to wrap output around the display (by default 80 chars).
         # This behavior is expected and cannot be changed, however it corrupts the XML e.g. newlines in the middle of
@@ -55,15 +81,17 @@ module PuppetX
         # newline characters are stripped. Then where required decoded from Base64 back into text
         out = REXML::Document.new(out.gsub(/\n/,""))
 
-        # picks up exitcode, errormessage and stdout
+        # picks up exitcode, errormessage, stdout and stderr
         props = REXML::XPath.each(out, '//Property').map do |prop|
           name = prop.attributes['Name']
           value = (name == 'exitcode') ?
             prop.text.to_i :
             (prop.text.nil? ? nil : Base64.decode64(prop.text))
+          # if err contains data it must be "real" stderr output
+          # which should be appended to what PS has already captured
+          value += err if err && (err != []) && (name == 'stderr')
           [name.to_sym, value]
         end
-        props << [:stderr, err]
 
         Hash[ props ]
       ensure
@@ -71,40 +99,37 @@ module PuppetX
       end
 
       def exit
+        @usable = false
+
         Puppet.debug "PowerShellManager exiting..."
-        @stdin.puts "\nexit\n"
-        @stdin.close
-        @stdout.close
-        @stderr.close
-
-        exit_msg = "PowerShell process did not terminate in reasonable time"
-        begin
-          Timeout.timeout(3) do
-            Puppet.debug "Awaiting PowerShell process termination..."
-            @exit_status = @ps_process.value
-          end
-        rescue Timeout::Error
-        end
-
-        exit_msg = "PowerShell process exited: #{@exit_status}" if @exit_status
-        Puppet.debug(exit_msg)
-        if @ps_process.alive?
-          Puppet.debug("Forcefully terminating PowerShell process.")
-          Process.kill('KILL', @ps_process[:pid])
-        end
+        # ignore any failure to call exit against PS process
+        @stdin.puts "\nexit\n" if !@stdin.closed? rescue nil
+        @stdin.close if !@stdin.closed?
+        @stdout.close if !@stdout.closed?
+        @stderr.close if !@stderr.closed?
       end
 
-      def template_path
-        File.expand_path('../../../templates', __FILE__)
+      def self.init_path
+        path = File.expand_path('../../../templates/iis', __FILE__)
+        path = File.join(path, 'init_ps.ps1').gsub('/', '\\')
+        "\"#{path}\""
       end
 
       def make_ps_init_code(init_ready_event_name)
-        template_file = File.new(template_path + "/iis/init_ps.ps1.erb").read
-        template = ERB.new(template_file, nil, '-')
-        template.result(binding)
+        debug_output = Puppet::Util::Log.level == :debug ? '-EmitDebugOutput' : ''
+        <<-CODE
+. #{self.class.init_path} -InitReadyEventName '#{init_ready_event_name}' #{debug_output}
+        CODE
       end
 
-      def make_ps_code(powershell_code, output_ready_event_name, timeout_ms = 300 * 1000)
+      def make_ps_code(powershell_code, output_ready_event_name, timeout_ms = nil, working_dir = nil)
+        begin
+          timeout_ms = Integer(timeout_ms)
+          # Lower bound protection. The polling resolution is only 50ms
+          if (timeout_ms < 50) then timeout_ms = 50 end
+        rescue
+          timeout_ms = 300 * 1000
+        end
         <<-CODE
 $params = @{
   Code = @'
@@ -112,20 +137,35 @@ $params = @{
 '@
   EventName = "#{output_ready_event_name}"
   TimeoutMilliseconds = #{timeout_ms}
+  WorkingDirectory = "#{working_dir}"
 }
 
 Invoke-PowerShellUserCode @params
-
-# always need a trailing newline to ensure PowerShell parses code
-
         CODE
       end
 
       private
 
       def self.is_readable?(stream, timeout = 0.5)
+        raise Errno::EPIPE if !is_stream_valid?(stream)
         read_ready = IO.select([stream], [], [], timeout)
         read_ready && stream == read_ready[0][0]
+      end
+
+      # when a stream has been closed by handle, but Ruby still has a file
+      # descriptor for it, it can be tricky to determine that it's actually dead
+      # the .fileno will still return an int, and calling get_osfhandle against
+      # it returns what the CRT thinks is a valid Windows HANDLE value, but
+      # that may no longer exist
+      def self.is_stream_valid?(stream)
+        # when a stream is closed, its obviously invalid, but Ruby doesn't always know
+        !stream.closed? &&
+        # so calling stat will yield an EBADF when underlying OS handle is bad
+        # as this resolves to a HANDLE and then calls the Windows API
+        !stream.stat.nil?
+      # any exceptions mean the stream is dead
+      rescue
+        false
       end
 
       # copied directly from Puppet 3.7+ to support Puppet 3.5+
@@ -169,7 +209,7 @@ Invoke-PowerShellUserCode @params
       WAIT_TIMEOUT = 0x00000102
       WAIT_FAILED = 0xFFFFFFFF
 
-      def self.wait_on(wait_object, timeout_ms = 1000)
+      def self.wait_on(wait_object, timeout_ms = 50)
         wait_result = WaitForSingleObject(wait_object, timeout_ms)
 
         case wait_result
@@ -191,56 +231,75 @@ Invoke-PowerShellUserCode @params
 
       def write_stdin(input)
         @stdin.puts(input)
-      rescue => e
-        msg = "Error writing STDIN / reading STDOUT: #{e}"
-        raise Puppet::Util::Windows::Error.new(msg)
       end
 
-      def drain_pipe(pipe, iterations = 10)
-        output = []
-        0.upto(iterations) do
-          break if !self.class.is_readable?(pipe, 0.1)
+      def read_from_pipe(pipe, timeout = 0.1, &block)
+        if self.class.is_readable?(pipe, timeout)
           l = pipe.gets
           Puppet.debug "#{Time.now} PIPE> #{l}"
-          output << l
+          # since gets can return a nil at EOF, skip returning that value
+          yield l if !l.nil?
         end
+
+        nil
+      end
+
+      def drain_pipe_until_signaled(pipe, signal)
+        output = []
+
+        read_from_pipe(pipe) { |s| output << s } until !signal.locked?
+
+        # there's ultimately a bit of a race here
+        # read one more time after signal is received
+        read_from_pipe(pipe, 0) { |s| output << s } until !self.class.is_readable?(pipe)
         output
       end
 
       def read_stdout(output_ready_event, wait_interval_ms = 50)
-        output = []
-        errors = []
-        waited = 0
+        pipe_done_reading = Mutex.new
+        pipe_done_reading.lock
+        start_time = Time.now
 
-        # drain the pipe while waiting for the event signal
+        stdout_reader = Thread.new { drain_pipe_until_signaled(@stdout, pipe_done_reading) }
+        stderr_reader = Thread.new { drain_pipe_until_signaled(@stderr, pipe_done_reading) }
+
+        # wait until an event signal
+        # OR a terminal state with child process / streams has been reached
         while WAIT_TIMEOUT == self.class.wait_on(output_ready_event, wait_interval_ms)
-          # TODO: While this does ensure that both pipes have been
-          # drained it can block on either longer than necessary or
-          # deadlock waiting for one or the other to finish. The correct
-          # way to deal with this is to drain each pipe from seperate threads
-          # but time ran on in this implementation and this will be addressed soon
-          output << drain_pipe(@stdout)
-          errors << drain_pipe(@stderr)
-          waited += wait_interval_ms
+          # if reader threads have died, likely due to closed streams / handles
+          break if !stdout_reader.alive? || !stderr_reader.alive?
+
+          # Ruby will gleefully allow trying to read stdout / stderr that are
+          # no longer connected to a live process, so therefore check the
+          # liveness here and raise the broken pipe error that Ruby would usually
+          # since stdin isn't checked here, fail if process dead instead
+          raise Errno::EPIPE if !@ps_process.alive?
         end
 
-        Puppet.debug "Waited #{waited} total milliseconds."
+        Puppet.debug "Waited #{Time.now - start_time} total seconds."
 
-        # once signaled, ensure everything has been drained
-        output << drain_pipe(@stdout, 1000)
-        errors << drain_pipe(@stderr, 1000)
+        # signal stdout / stderr readers via mutex
+        pipe_done_reading.unlock
 
-        errors = errors.reject { |e| e.empty? }
-
-        return output.join(''), errors
-      rescue => e
-        msg = "Error reading PIPE: #{e}"
-        raise Puppet::Util::Windows::Error.new(msg)
+        [
+          stdout_reader.value.join(''),
+          stderr_reader.value
+        ]
       end
 
       def exec_read_result(powershell_code, output_ready_event)
         write_stdin(powershell_code)
         read_stdout(output_ready_event)
+      # if any pipes are broken, the manager is totally hosed
+      # bad file descriptors mean closed stream handles
+      rescue Errno::EPIPE, Errno::EBADF => e
+        @usable = false
+        return nil, [e.inspect, e.backtrace].flatten
+      # catch closed stream errors specifically
+      rescue IOError => ioerror
+        raise if !ioerror.message.start_with?('closed stream')
+        @usable = false
+        return nil, [ioerror.inspect, ioerror.backtrace].flatten
       end
 
       if Puppet::Util::Platform.windows?

--- a/spec/integration/puppet_x/puppetlabs/iis/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/iis/powershell_manager_spec.rb
@@ -3,26 +3,231 @@ require 'puppet/type'
 require 'puppet_x/puppetlabs/iis/powershell_manager'
 
 module PuppetX
-  module PowerShell
+  module IIS
     class PowerShellManager; end
+    if Puppet::Util::Platform.windows?
+      module WindowsAPI
+        require 'ffi'
+        extend FFI::Library
+
+        ffi_convention :stdcall
+
+        # https://msdn.microsoft.com/en-us/library/ks2530z6%28v=VS.100%29.aspx
+        # intptr_t _get_osfhandle(
+        #    int fd
+        # );
+        ffi_lib [FFI::CURRENT_PROCESS, 'msvcrt']
+        attach_function :get_osfhandle, :_get_osfhandle, [:int], :uintptr_t
+
+        # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
+        # BOOL WINAPI CloseHandle(
+        #   _In_  HANDLE hObject
+        # );
+        ffi_lib :kernel32
+        attach_function :CloseHandle, [:uintptr_t], :int32
+      end
+    end
   end
 end
 
 describe PuppetX::IIS::PowerShellManager,
-  :if => Puppet::Util::Platform.windows? && PuppetX::IIS::PowerShellManager.supported? do
-
-  let (:manager) {
-    # provider = Puppet::Type.type(:iis_site).provider(:iispowershell)
-    # powershell = provider.command(:powershell)
-    # powershell_args = provider.powershell_args
-    PuppetX::IIS::PowerShellManager.instance("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command -")
+  :if => Puppet::Util::Platform.windows? && PuppetX::IIS::PowerShellManager.supported?,
+  :skip => (Puppet::Util::Platform.windows? && PuppetX::IIS::PowerShellManager.supported? && get_powershell_major_version >= 3) ? false : "Powershell version is less than 3.0 or undetermined" do
+  
+  let (:manager_args) {
+    provider = Puppet::Type.type(:exec).provider(:powershell)
+    powershell = provider.command(:powershell)
+    cli_args = provider.powershell_args
+    "#{powershell} #{cli_args.join(' ')}"
   }
+
+  def create_manager
+    PuppetX::IIS::PowerShellManager.instance(manager_args)
+  end
+
+  let (:manager) { create_manager() }
+
+  describe "when managing the powershell process" do
+    describe "the PowerShellManager::instance method" do
+      it "should return the same manager instance / process given the same cmd line" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        manager_2 = create_manager()
+        second_pid = manager_2.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        expect(manager_2).to eq(manager)
+        expect(first_pid).to eq(second_pid)
+      end
+
+      def bad_file_descriptor_regex
+        # Ruby can do something like:
+        # <Errno::EBADF: Bad file descriptor>
+        # <Errno::EBADF: Bad file descriptor @ io_fillbuf - fd:10 >
+        @bad_file_descriptor_regex ||= (
+          ebadf = Errno::EBADF.new()
+          '^' + Regexp.escape("\#<#{ebadf.class}: #{ebadf.message}")
+        )
+      end
+
+      # reason can be a single string / regex or an array of them
+      # by default the matches are treated as literal
+      def expect_dead_manager(manager, reason, style = :exact)
+        # additional attempts to use the manager will fail for the given reason
+        result = manager.execute('Write-Host "hi"')
+        expect(result[:exitcode]).to eq(-1)
+
+        if reason.is_a?(String)
+          expect(result[:stderr][0]).to eq(reason) if style == :exact
+          expect(result[:stderr][0]).to match(reason) if style == :regex
+        elsif reason.is_a?(Array)
+          expect(reason).to include(result[:stderr][0]) if style == :exact
+          if style == :regex
+            expect(result[:stderr][0]).to satisfy("should match expected error(s): #{reason}") do |msg|
+              reason.any? { |m| msg.match m }
+            end
+          end
+        end
+
+        # and the manager no longer considers itself alive
+        expect(manager.alive?).to eq(false)
+      end
+
+      def expect_different_manager_returned_than(manager, pid)
+        # acquire another manager instance
+        new_manager = create_manager()
+
+        # which should be different than the one passed in
+        expect(new_manager).to_not eq(manager)
+
+        # with a different PID
+        second_pid = new_manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        expect(pid).to_not eq(second_pid)
+      end
+
+      def close_stream(stream, style = :inprocess)
+        if style == :inprocess
+          stream.close
+        else style == :viahandle
+          handle = PuppetX::PowerShell::WindowsAPI.get_osfhandle(stream.fileno)
+          PuppetX::PowerShell::WindowsAPI.CloseHandle(handle)
+        end
+      end
+
+      it "should create a new PowerShell manager host if user code exits the first process" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+        exitcode = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Kill()')[:exitcode]
+
+        # when a process gets torn down out from under manager before reading stdout
+        # it catches the error and returns a -1 exitcode
+        expect(exitcode).to eq(-1)
+
+        expect_dead_manager(manager, Errno::EPIPE.new().inspect, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the underlying PowerShell process is killed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # kill the PID from Ruby
+        process = manager.instance_variable_get(:@ps_process)
+        Process.kill('KILL', process.pid)
+
+        expect_dead_manager(manager, Errno::EPIPE.new().inspect, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the input stream is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # closing stdin from the Ruby side tears down the process
+        close_stream(manager.instance_variable_get(:@stdin), :inprocess)
+
+        expect_dead_manager(manager, IOError.new('closed stream').inspect, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the input stream handle is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # call CloseHandle against stdin, therby tearing down the PowerShell process
+        close_stream(manager.instance_variable_get(:@stdin), :viahandle)
+
+        expect_dead_manager(manager, bad_file_descriptor_regex, :regex)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the output stream is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # closing stdout from the Ruby side allows process to run
+        close_stream(manager.instance_variable_get(:@stdout), :inprocess)
+
+        # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
+        msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
+        expect_dead_manager(manager, msgs, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the output stream handle is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # call CloseHandle against stdout, which leaves PowerShell process running
+        close_stream(manager.instance_variable_get(:@stdout), :viahandle)
+
+        # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
+        msgs = [
+          '^' + Regexp.escape(Errno::EPIPE.new().inspect),
+          bad_file_descriptor_regex
+        ]
+        expect_dead_manager(manager, msgs, :regex)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the error stream is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # closing stderr from the Ruby side allows process to run
+        close_stream(manager.instance_variable_get(:@stderr), :inprocess)
+
+        # fails with vanilla EPIPE or closed stream IOError depening on timing / Ruby version
+        msgs = [ Errno::EPIPE.new().inspect, IOError.new('closed stream').inspect ]
+        expect_dead_manager(manager, msgs, :exact)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+
+      it "should create a new PowerShell manager host if the error stream handle is closed" do
+        first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
+
+        # call CloseHandle against stderr, which leaves PowerShell process running
+        close_stream(manager.instance_variable_get(:@stderr), :viahandle)
+
+        # fails with vanilla EPIPE or various EBADF depening on timing / Ruby version
+        msgs = [
+          '^' + Regexp.escape(Errno::EPIPE.new().inspect),
+          bad_file_descriptor_regex
+        ]
+        expect_dead_manager(manager, msgs, :regex)
+
+        expect_different_manager_returned_than(manager, first_pid)
+      end
+    end
+  end
+
+  let(:powershell_runtime_error) { '$ErrorActionPreference = "Stop";$test = 1/0' }
+  let(:powershell_parseexception_error) { '$ErrorActionPreference = "Stop";if (1 -badoperator 2) { Exit 1 }' }
+  let(:powershell_incompleteparseexception_error) { '$ErrorActionPreference = "Stop";if (1 -eq 2) {  ' }
 
   describe "when provided powershell commands" do
     it "shows ps version" do
       result = manager.execute('$psversiontable')
-      # puts result[:stdout]
-      expect(result[:stdout]).not_to eq(nil)
+      puts result[:stdout]
     end
 
     it "should return simple output" do
@@ -48,11 +253,26 @@ describe PuppetX::IIS::PowerShellManager,
       expect(result[:exitcode]).to eq(1)
     end
 
+    it "should return the exitcode of the last command to set an exit code" do
+      result = manager.execute("$LASTEXITCODE = 0; write-output 'foo'; cmd.exe /c 'exit 99'; write-output 'bar'")
+
+      # STDERR is interpolating the newlines thus it's \n instead of the usual Windows \r\n
+      expect(result[:stdout]).to eq("foo\r\nbar\r\n")
+      expect(result[:exitcode]).to eq(99)
+    end
+
+    it "should return the exitcode of a script invoked with the call operator &" do
+      fixture_path = File.expand_path(File.dirname(__FILE__) + '../../../../exit-27.ps1')
+      result = manager.execute("& #{fixture_path}")
+
+      expect(result[:stdout]).to eq(nil)
+      expect(result[:exitcode]).to eq(27)
+    end
+
     it "should collect anything written to stderr" do
       result = manager.execute('[System.Console]::Error.WriteLine("foo")')
 
-      # STDERR is interpolating the newlines thus it's \n instead of the usual Windows \r\n
-      expect(result[:stderr][0][0]).to eq("foo\n")
+      expect(result[:stderr]).to eq("foo\r\n")
       expect(result[:exitcode]).to eq(0)
     end
 
@@ -60,7 +280,7 @@ describe PuppetX::IIS::PowerShellManager,
       result = manager.execute('ps;[System.Console]::Error.WriteLine("foo")')
 
       expect(result[:stdout]).not_to eq(nil)
-      expect(result[:stderr]).not_to eq(nil)
+      expect(result[:stderr]).to eq("foo\r\n")
       expect(result[:exitcode]).to eq(0)
     end
 
@@ -160,6 +380,19 @@ try {
       expect(result[:stdout]).to eq("False\r\n")
     end
 
+    it "should be able to write more than the 64k default buffer size to the managers pipe without deadlocking the Ruby parent process or breaking the pipe" do
+      # this was tested successfully up to 5MB of text
+      buffer_string_96k = 'a' * ((1024 * 96) + 1)
+      result = manager.execute(<<-CODE
+'#{buffer_string_96k}' | Write-Output
+        CODE
+        )
+
+      expect(result[:errormessage]).to eq(nil)
+      expect(result[:exitcode]).to eq(0)
+      expect(result[:stdout]).to eq("#{buffer_string_96k}\r\n")
+    end
+
     it "should be able to write more than the 64k default buffer size to child process stdout without deadlocking the Ruby parent process" do
       result = manager.execute(<<-CODE
 $bytes_in_k = (1024 * 64) + 1
@@ -188,6 +421,95 @@ $bytes_in_k = (1024 * 64) + 1
         )
 
       expect(result[:errormessage]).not_to be_empty
+    end
+
+    it "should error if working directory does not exist" do
+      work_dir = 'C:/some/directory/that/does/not/exist'
+
+      result = manager.execute('(Get-Location).Path',nil,work_dir)
+
+      expect(result[:exitcode]).to_not eq(0)
+      expect(result[:errormessage]).to match(/Working directory .+ does not exist/)
+    end
+
+    it "should allow forward slashes in working directory" do
+      work_dir = ENV["WINDIR"]
+      forward_work_dir = work_dir.gsub('\\','/')
+
+      result = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
+
+      expect(result).to eq("#{work_dir}\r\n")
+    end
+
+    it "should use a specific working directory if set" do
+      work_dir = ENV["WINDIR"]
+
+      result = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
+
+      expect(result).to eq("#{work_dir}\r\n")
+    end
+
+    it "should not reuse the same working directory between runs" do
+      work_dir = ENV["WINDIR"]
+      current_work_dir = Dir.getwd
+
+      first_cwd = manager.execute('(Get-Location).Path',nil,work_dir)[:stdout]
+      second_cwd = manager.execute('(Get-Location).Path')[:stdout]
+
+      # Paths should be case insensitive
+      expect(first_cwd.downcase).to eq("#{work_dir}\r\n".downcase)
+      expect(second_cwd.downcase).to eq("#{current_work_dir}\r\n".downcase)
+    end
+
+    context "with runtime error" do
+      it "should not refer to 'EndInvoke' or 'throw' for a runtime error" do
+        result = manager.execute(powershell_runtime_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:errormessage]).not_to match(/throw/)
+      end
+
+      it "should display line and char information for a runtime error" do
+        result = manager.execute(powershell_runtime_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).to match(/At line\:\d+ char\:\d+/)
+      end
+    end
+
+    context "with ParseException error" do
+      it "should not refer to 'EndInvoke' or 'throw' for a ParseException error" do
+        result = manager.execute(powershell_parseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:errormessage]).not_to match(/throw/)
+      end
+
+      it "should display line and char information for a ParseException error" do
+        result = manager.execute(powershell_parseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).to match(/At line\:\d+ char\:\d+/)
+      end
+    end
+
+    context "with IncompleteParseException error" do
+      it "should not refer to 'EndInvoke' or 'throw' for an IncompleteParseException error" do
+        result = manager.execute(powershell_incompleteparseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/EndInvoke/)
+        expect(result[:errormessage]).not_to match(/throw/)
+      end
+
+      it "should not display line and char information for an IncompleteParseException error" do
+        result = manager.execute(powershell_incompleteparseexception_error)
+
+        expect(result[:exitcode]).to eq(1)
+        expect(result[:errormessage]).not_to match(/At line\:\d+ char\:\d+/)
+      end
     end
   end
 
@@ -252,14 +574,14 @@ $bytes_in_k = (1024 * 64) + 1
       expect(result[:exitcode]).to eq(0)
     end
 
-    # it "should handle shell redirection" do
-    #   # the test here is to ensure that this doesn't break. because we merge the streams regardless
-    #   # the opposite of this test shows the same thing
-    #   result = manager.execute('function test-warning{ ps;write-warning \'foo\' }; test-warning 3>&1')
+    it "should handle shell redirection" do
+      # the test here is to ensure that this doesn't break. because we merge the streams regardless
+      # the opposite of this test shows the same thing
+      result = manager.execute('function test-error{ ps;write-error \'foo\' }; test-error 2>&1')
 
-    #   expect(result[:stdout]).not_to eq(nil)
-    #   expect(result[:exitcode]).to eq(0)
-    # end
+      expect(result[:stdout]).not_to eq(nil)
+      expect(result[:exitcode]).to eq(0)
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,32 @@ if Puppet.version.to_f >= 4.5
   end
 end
 
+if Puppet.features.microsoft_windows?
+  require 'puppet/util/windows/security'
+
+  def take_ownership(path)
+    path = path.gsub('/', '\\')
+    output = %x(takeown.exe /F #{path} /R /A /D Y 2>&1)
+    if $? != 0 #check if the child process exited cleanly.
+      puts "#{path} got error #{output}"
+    end
+  end
+
+  def get_powershell_major_version()
+    provider = Puppet::Type.type(:iis_powershell)
+    
+    begin
+      psversion = provider.powershell_version.split(".").first
+      # psversion = `#{powershell} -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command \"$PSVersionTable.PSVersion.Major.ToString()\"`.chomp!.to_i
+      puts "PowerShell major version number is #{psversion}"
+    rescue
+      puts "Unable to determine PowerShell version"
+      psversion = -1    
+    end
+    psversion
+  end
+end
+
 # put local configuration and setup into spec_helper_local
 begin
   require 'spec_helper_local'


### PR DESCRIPTION
This updates the PowerShell manager code to the latest powershell module 2.1.0 which supports WMF 5.1 as well as some speed improvements.

This also paves the way for 2016 to be added to the jenkins pipeline. Note this does not add support to the iis module for 2016. That requires another set of work yet to be documented, the least of which means adding confines and providers for