### PR TITLE
{DO NOT MERGE} Revert "Make IIS's Rototilled rakefile install from alternate forge"

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,32 +2,48 @@ require 'beaker-rspec/helpers/serverspec'
 require 'beaker-rspec/spec_helper'
 require 'beaker/puppet_install_helper'
 require 'beaker/testmode_switcher/dsl'
-require 'beaker/module_install_helper'
 
 # automatically load any shared examples or contexts
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 run_puppet_install_helper
-install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ /pe/i
 
-# Install iis module either from source or from staging forge if given correct env variables
 unless ENV['MODULE_provision'] == 'no'
-  if ENV.has_key?('BEAKER_FORGE_HOST') && ENV.has_key?('BEAKER_FORGE_API')
-    module_version = ENV.has_key?('MODULE_VERSION') || '>= 0.1.0'
-    install_module_from_forge_on(agents, 'puppetlabs-iis', module_version)
-  else
-    install_module_on(agents)
+  # hardcode distmoduledir while beaker-rspec can't remember it across re-runs of the testsuite
+  distmoduledir = '/cygdrive/c/ProgramData/PuppetLabs/code/modules'
+  on default, "mkdir -p #{distmoduledir}/iis"
+  result = on default, "echo #{distmoduledir}/iis"
+  target = result.raw_output.chomp
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  %w(lib metadata.json).each do |file|
+    scp_to default, "#{proj_root}/#{file}", target
   end
 end
 
 RSpec.configure do |c|
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
   # Configure all nodes in nodeset
   c.before :suite do
-    unless ENV['BEAKER_TESTMODE'] == 'local' || ENV['BEAKER_provision'] == 'o'
-      install_module_from_forge_on(agents, 'puppet/windowsfeature', '>= 2.0.0')
-      pp = "windowsfeature { ['Web-WebServer','Web-Scripting-Tools']: ensure => present }"
-      apply_manifest_on(agents, pp)
+    unless ENV['BEAKER_TESTMODE'] == 'local'
+      unless ENV['BEAKER_provision'] == 'no'
+        shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
+        # install iis
+        on(agents, puppet("module install puppet/windowsfeature"))
+        pp=<<-EOS
+    $iis_features = ['Web-WebServer','Web-Scripting-Tools']
+
+    windowsfeature { $iis_features:
+      ensure => present,
+    }
+        EOS
+        apply_manifest(pp)
+      end
     end
+  end
+  c.after :suite do
+    absent_files = 'file{["c:/services.txt","c:/process.txt","c:/try_success.txt","c:/catch_shouldntexist.txt","c:/try_shouldntexist.txt","c:/catch_success.txt"]: ensure => absent }'
+    apply_manifest(absent_files)
   end
 end
 


### PR DESCRIPTION
This reverts commit dc9fb4c0aea330579cb621464e0b3fc73f3c7ade for the
`spec_helper_acceptance.rb` file only.