### PR TITLE
(maint) Fix lost dism commit

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,9 +23,9 @@ end
 RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
-    unless ENV['BEAKER_TESTMODE'] == 'local' || ENV['BEAKER_provision'] == 'o'
-      install_module_from_forge_on(agents, 'puppet/windowsfeature', '>= 2.0.0')
-      pp = "windowsfeature { ['Web-WebServer','Web-Scripting-Tools']: ensure => present }"
+    unless ENV['BEAKER_TESTMODE'] == 'local' || ENV['BEAKER_provision'] == 'no'
+      install_module_from_forge_on(agents, 'puppetlabs/dism', '>= 1.2.0')
+      pp = "dism { ['IIS-WebServerRole','IIS-WebServer', 'IIS-WebServerManagementTools']: ensure => present }"
       apply_manifest_on(agents, pp)
     end
   end


### PR DESCRIPTION
This commit adds the dism module back to the spec helper that was lost in a bad merge