### PR TITLE
[MODULES-4165] Implement beaker-testmode_switcher

### DIFF
--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -16,7 +16,7 @@ describe 'iis_application_pool' do
 
       context 'when puppet resource is run' do
         before(:all) do
-          @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+          @result = resource('iis_application_pool', @pool_name)
         end
 
         puppet_resource_should_show('ensure', 'present')
@@ -45,8 +45,9 @@ describe 'iis_application_pool' do
 
       context 'when puppet resource is run' do
         before(:all) do
-          @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+          @result = resource('iis_application_pool', @pool_name)
         end
+
         puppet_resource_should_show('ensure', 'present')
 
         # Properties introduced in IIS 7.0 (Server 2008 - Kernel 6.1)
@@ -106,8 +107,9 @@ describe 'iis_application_pool' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+            @result = resource('iis_application_pool', @pool_name)
           end
+
           puppet_resource_should_show('ensure', 'absent')
         end
 
@@ -131,8 +133,9 @@ describe 'iis_application_pool' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+            @result = resource('iis_application_pool', @pool_name)
           end
+
           puppet_resource_should_show('ensure', 'absent')
         end
 
@@ -160,7 +163,7 @@ describe 'iis_application_pool' do
 
     context 'when puppet resource is run' do
       before(:all) do
-        @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+        @result = resource('iis_application_pool', @pool_name)
       end
 
       puppet_resource_should_show('ensure', 'present')
@@ -189,7 +192,7 @@ describe 'iis_application_pool' do
 
     context 'when puppet resource is run' do
       before(:all) do
-        @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
+        @result = resource('iis_application_pool', @pool_name)
       end
 
       puppet_resource_should_show('ensure', 'absent')

--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -19,7 +19,6 @@ describe 'iis_application_pool' do
           @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
         end
 
-        include_context 'with a puppet resource run'
         puppet_resource_should_show('ensure', 'present')
       end
 
@@ -48,8 +47,6 @@ describe 'iis_application_pool' do
         before(:all) do
           @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
         end
-        
-        include_context 'with a puppet resource run'
         puppet_resource_should_show('ensure', 'present')
 
         # Properties introduced in IIS 7.0 (Server 2008 - Kernel 6.1)
@@ -111,7 +108,6 @@ describe 'iis_application_pool' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
           end
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure', 'absent')
         end
 
@@ -137,7 +133,6 @@ describe 'iis_application_pool' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
           end
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure', 'absent')
         end
 
@@ -168,7 +163,6 @@ describe 'iis_application_pool' do
         @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
       end
 
-      include_context 'with a puppet resource run'
       puppet_resource_should_show('ensure', 'present')
       puppet_resource_should_show('state', 'Started')
     end
@@ -198,7 +192,6 @@ describe 'iis_application_pool' do
         @result = on(default, puppet('resource', 'iis_application_pool', "#{@pool_name}"))
       end
 
-      include_context 'with a puppet resource run'
       puppet_resource_should_show('ensure', 'absent')
     end
   end

--- a/spec/acceptance/iis_feature.rb
+++ b/spec/acceptance/iis_feature.rb
@@ -21,15 +21,11 @@ describe 'iis_feature' do
         include_context 'with a puppet resource run'
         puppet_resource_should_show('ensure', 'present')
       end
-
-      after(:all) do
-      end
     end
 
     context 'with invalid' do
       context 'name parameter defined' do
         before(:all) do
-          @pool_name = "#{SecureRandom.hex(10)}"
           @manifest  = <<-HERE
           iis_feature { 'Foo':
             ensure => 'present'
@@ -38,9 +34,6 @@ describe 'iis_feature' do
         end
 
         it_behaves_like 'a failing manifest'
-
-        after(:all) do
-        end
       end
 
     end

--- a/spec/acceptance/iis_feature.rb
+++ b/spec/acceptance/iis_feature.rb
@@ -15,10 +15,9 @@ describe 'iis_feature' do
 
       context 'when puppet resource is run' do
         before(:all) do
-          @result = on(default, puppet('resource', 'iis_feature', "Web-Asp-Net45"))
+          @result = resource('iis_feature', 'Web-Asp-Net45')
         end
 
-        include_context 'with a puppet resource run'
         puppet_resource_should_show('ensure', 'present')
       end
     end

--- a/spec/acceptance/iis_minimal_config_spec.rb
+++ b/spec/acceptance/iis_minimal_config_spec.rb
@@ -14,7 +14,6 @@ iis_site { 'minimal':
   applicationpool => 'DefaultAppPool',
 }
     EOF
-    @result = apply_manifest(@manifest, acceptable_exit_codes: (0...256))
   end
 
   it_behaves_like 'an idempotent resource'

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -24,7 +24,7 @@ describe 'iis_site' do
 
       context 'when puppet resource is run' do
         before(:all) do
-          @result = on(default, puppet('resource', 'iis_site', @site_name))
+          @result = resource('iis_site', @site_name)
         end
         puppet_resource_should_show('ensure', 'started')
         puppet_resource_should_show('physicalpath', 'C:\inetpub\basic')
@@ -84,7 +84,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('ensure',               'started')
           puppet_resource_should_show('applicationpool',      'DefaultAppPool')
@@ -141,7 +141,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('ensure',               'started')
           puppet_resource_should_show('applicationpool',      'DefaultAppPool')
@@ -178,7 +178,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('ensure', 'started')
           puppet_resource_should_show('physicalpath', 'C:\inetpub\tmp')
@@ -208,7 +208,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('ensure', 'stopped')
           puppet_resource_should_show('physicalpath', 'C:\inetpub\tmp')
@@ -235,7 +235,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('ensure', 'absent')
         end
@@ -305,7 +305,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('physicalpath', 'C:\\inetpub\\new')
         end
@@ -344,7 +344,7 @@ describe 'iis_site' do
             ],
           }
           HERE
-          apply_manifest(setup_manifest, :catch_failures => true)
+          execute_manifest(setup_manifest, :catch_failures => true)
 
           @manifest = <<-HERE
           iis_site { '#{@site_name}':
@@ -369,7 +369,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           #puppet_resource_should_show('bindings', [
           #  {
@@ -399,7 +399,7 @@ describe 'iis_site' do
             applicationpool  => 'DefaultAppPool',
           }
           HERE
-          apply_manifest(setup_manifest, :catch_failures => true)
+          execute_manifest(setup_manifest, :catch_failures => true)
 
           @manifest = <<-HERE
           iis_site { '#{@site_name}':
@@ -415,7 +415,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('enabledprotocols', 'https')
         end
@@ -438,7 +438,7 @@ describe 'iis_site' do
             logflags         => ['ClientIP', 'Date', 'HttpStatus']
           }
           HERE
-          apply_manifest(setup_manifest, :catch_failures => true)
+          execute_manifest(setup_manifest, :catch_failures => true)
 
           @manifest = <<-HERE
           iis_site { '#{@site_name}':
@@ -455,7 +455,7 @@ describe 'iis_site' do
 
         context 'when puppet resource is run' do
           before(:all) do
-            @result = on(default, puppet('resource', 'iis_site', @site_name))
+            @result = resource('iis_site', @site_name)
           end
           puppet_resource_should_show('logflags', ['ClientIP', 'Date', 'Method'])
         end

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -26,8 +26,6 @@ describe 'iis_site' do
         before(:all) do
           @result = on(default, puppet('resource', 'iis_site', @site_name))
         end
-
-        include_context 'with a puppet resource run'
         puppet_resource_should_show('ensure', 'started')
         puppet_resource_should_show('physicalpath', 'C:\inetpub\basic')
         puppet_resource_should_show('applicationpool', 'DefaultAppPool')
@@ -88,8 +86,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure',               'started')
           puppet_resource_should_show('applicationpool',      'DefaultAppPool')
           puppet_resource_should_show('enabledprotocols',     'https')
@@ -147,8 +143,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure',               'started')
           puppet_resource_should_show('applicationpool',      'DefaultAppPool')
           puppet_resource_should_show('enabledprotocols',     'https')
@@ -186,8 +180,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure', 'started')
           puppet_resource_should_show('physicalpath', 'C:\inetpub\tmp')
           puppet_resource_should_show('applicationpool', 'DefaultAppPool')
@@ -218,8 +210,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure', 'stopped')
           puppet_resource_should_show('physicalpath', 'C:\inetpub\tmp')
           puppet_resource_should_show('applicationpool', 'DefaultAppPool')
@@ -247,8 +237,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('ensure', 'absent')
         end
 
@@ -319,8 +307,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('physicalpath', 'C:\\inetpub\\new')
         end
 
@@ -385,8 +371,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           #puppet_resource_should_show('bindings', [
           #  {
           #    "protocol"             => "http",
@@ -433,8 +417,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('enabledprotocols', 'https')
         end
 
@@ -475,8 +457,6 @@ describe 'iis_site' do
           before(:all) do
             @result = on(default, puppet('resource', 'iis_site', @site_name))
           end
-
-          include_context 'with a puppet resource run'
           puppet_resource_should_show('logflags', ['ClientIP', 'Date', 'Method'])
         end
 

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -443,7 +443,7 @@ describe 'iis_site' do
         end
       end
 
-      context 'logflags', :focus => true do
+      context 'logflags' do
         before(:all) do
           create_path('C:\inetpub\new')
           @site_name = "#{SecureRandom.hex(10)}"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,9 +14,11 @@ install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ /pe/i
 unless ENV['MODULE_provision'] == 'no'
   if ENV.has_key?('BEAKER_FORGE_HOST') && ENV.has_key?('BEAKER_FORGE_API')
     module_version = ENV.has_key?('MODULE_VERSION') || '>= 0.1.0'
-    install_module_from_forge_on(agents, 'puppetlabs-iis', module_version)
+    install_module_from_forge_on(hosts, 'puppetlabs-iis', module_version)
   else
-    install_module_on(agents)
+    hosts.each do |host|
+      install_module_on(host)
+    end
   end
 end
 
@@ -24,9 +26,10 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     unless ENV['BEAKER_TESTMODE'] == 'local' || ENV['BEAKER_provision'] == 'no'
-      install_module_from_forge_on(agents, 'puppetlabs/dism', '>= 1.2.0')
+      windows_hosts = hosts.select { |host| host.platform =~ /windows/i }
+      install_module_from_forge_on(windows_hosts, 'puppetlabs/dism', '>= 1.2.0')
       pp = "dism { ['IIS-WebServerRole','IIS-WebServer', 'IIS-WebServerManagementTools']: ensure => present }"
-      apply_manifest_on(agents, pp)
+      apply_manifest_on(windows_hosts, pp)
     end
   end
 end

--- a/spec/support/examples/failing_manifest.rb
+++ b/spec/support/examples/failing_manifest.rb
@@ -1,5 +1,5 @@
 shared_examples 'a failing manifest' do
   it 'should run with errors' do
-    apply_manifest(@manifest, :expect_failures => true)
+    execute_manifest(@manifest, :expect_failures => true)
   end
 end

--- a/spec/support/examples/idempotent_resource.rb
+++ b/spec/support/examples/idempotent_resource.rb
@@ -1,9 +1,9 @@
 shared_examples 'an idempotent resource' do
   it 'should run without errors' do
-    apply_manifest(@manifest, :catch_failures => true)
+    execute_manifest(@manifest, :catch_failures => true)
   end
 
   it 'should run a second time without changes' do
-    apply_manifest(@manifest, :catch_changes => true)
+    execute_manifest(@manifest, :catch_changes => true)
   end
 end


### PR DESCRIPTION
This PR implements beaker-testmode_switcher in the acceptance tests of this module. 

This implements the `execute_manifest` function and depending on how the BEAKER_TESTMODE env var is set, will apply the given manifest on the SUT using the `puppet apply` command or do a full puppet agent run by copying the manifest to the site.pp of the master and then run `puppet agent` on the SUT.

A number of other changes were made to the acceptance test suite with some general cleanup:
- (maint) Remove :focus tag from iis_site_spec.rb that has been left in previously from debugging
- (maint) Remove unnecessary usage of shared context 'with a puppet resource run', which doesn't actually run puppet resource any longer
- (maint) Remove apply_manifest from iis_minimal_config_spec.rb, the shared example 'an idempotent resource' is called which runs apply_manifest twice to ensure idempotency, making calling it from iis_minimal_config_spec unnecessary
- (maint) Remove unnecessary `after(:all)` blocks from iis_feature.rb

Then the following changes were made for beaker-testmode_switcher
- Made necessary changes to spec_helper_acceptance to support both master/agent and agent only setups
- Implemented beaker-testmode_switcher's `execute_manifest` and `resource` methods in place of `apply_manifest` and `on(default, puppet('resource', ... )`.