### PR TITLE
(maint) Make exists? just use the :ensure value

### DIFF
--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -12,10 +12,7 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
   mk_resource_methods
 
   def exists?
-    inst_cmd = "Get-WebConfiguration -Filter '/system.applicationHost/applicationPools/add' | ? { $_.Name -eq '#{@resource[:name]}' }"
-    result   = self.class.run(inst_cmd)
-    resp     = result[:stdout]
-    return resp.nil? ? false : true
+    @resource[:ensure] == :present
   end
 
   def create


### PR DESCRIPTION
This change 1/2s the time needed to create or destroy app pools.

Previously the exists? method would fetch the current state of every
resource. This state would have already been fetched when the
self.instances method instatiated the providers so as long as there are
no pools created outside of puppet's control between the time that
self.instances runs (before the first iis_application_pool resource is
evaluated) and the time that exists? runs (at least once per resource
evaluation) then the state will not have changed underneath it.

If application pools would be created mid-puppet-run by something other
than puppet (say, if creating a website automatically creates a default
pool) then this change could be not aware of the new state.