### PR TITLE
(FM-5969) Prepare for unsupported release 0.1.0

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -19,11 +19,8 @@ MAINTAINERS.md:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"
 NOTICE:
   copyright_holders:
-    - name: 'OpenTable'
-      begin: 2012
-      end: 2015
     - name: 'Puppet, Inc.'
-      begin: 2015
+      begin: 2017
 
 # already using master branch's version
 spec/spec_helper.rb:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,11 @@
-##2017-XX-XX - Version 0.1.0
+## 2017-03-16 - Version 0.1.0
+
 ### Summary
-This is the initial, unsupported release with functionality to manage IIS application pools, sites, applications and more.
+This is the initial, unsupported release with functionality to manage IIS application pools, sites and installation.
+
 ### Features
 - Added `iis_version` fact
 - Added Types/Providers
-  - `iis_application_pool`
-    - [MODULES-4219](https://tickets.puppetlabs.com/browse/MODULES-4219)
-    - [MODULES-4220](https://tickets.puppetlabs.com/browse/MODULES-4220)
-  - `iis_site`
-    - [MODULES-3049](https://tickets.puppetlabs.com/browse/MODULES-3049)
-    - [MODULES-3887](https://tickets.puppetlabs.com/browse/MODULES-3887)
-  - `iis_application`
-    - [MODULES-3050](https://tickets.puppetlabs.com/browse/MODULES-3050)
-  - `iis_virtual_directory`
-    - [MODULES-3053](https://tickets.puppetlabs.com/browse/MODULES-3053)
+  - `iis_site` ([MODULES-3049](https://tickets.puppetlabs.com/browse/MODULES-3049), [MODULES-3887](https://tickets.puppetlabs.com/browse/MODULES-3887))
+  - `iis_application` ([MODULES-3050](https://tickets.puppetlabs.com/browse/MODULES-3050))
+  - `iis_feature` ([MODULES-4434](https://tickets.puppetlabs.com/browse/MODULES-4434))

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,6 @@
 Puppet Module - puppetlabs-iis
 
-Copyright 2012 - 2015 OpenTable
-Copyright 2015 Puppet, Inc.
+Copyright 2017 Puppet, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     * [Facts](#facts)
     * [Types/Providers](#types/providers)
         * [iis_application_pool](#iis_application_pool)
-        * [iis_site](#iis_site)
         * [iis_feature](#iis_feature)
+        * [iis_site](#iis_site)
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
@@ -68,8 +68,8 @@ iis_site { 'minimal':
 ### Types/Providers
 
 * [iis_application_pool](#iis_application_pool)
-* [iis_site](#iis_site)
 * [iis_feature](#iis_feature)
+* [iis_site](#iis_site)
 
 Here, include a complete list of your module's classes, types, providers, facts, along with the parameters for each. Users refer to this section (thus the name "Reference") to find specific details; most users don't read it per se.
 
@@ -222,10 +222,10 @@ Optionally include a source path for the installation media for an IIS feature
 ### Compatibility
 
 #### OS Compatibility
-This module is compatible only with `Windows Server 2008R2`, `Windows Server 2012`, `Windows Server 2012R2` & `Windows Server 2016`. 
+This module is compatible only with `Windows Server 2012` and `Windows Server 2012R2`.
 
 #### IIS Compatibility
-This module only supports `IIS 7.5`, `IIS 8` or `IIS 8.5`.
+This module only supports `IIS 8` or `IIS 8.5`.
 
 #### Powershell Compatibility
 This module requires Powershell v2 or greater. Works best with PowerShell v3 or above.

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version"     : "0.1.0",
   "author"      : "puppetlabs",
   "license"     : "Apache-2.0",
-  "summary"     : "Manage IIS for Windows Server 2008 and above. Maintain application sites, pools, virtual applications, and many other IIS settings.",
+  "summary"     : "Manage IIS for Windows Server 2012 and 2012R2. Maintain application sites, pools and installation.",
   "source"      : "https://github.com/puppetlabs/puppetlabs-iis.git",
   "project_page": "https://github.com/puppetlabs/puppetlabs-iis",
   "issues_url"  : "https://tickets.puppet.com/browse/MODULES",
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
-        "2008R2",
         "2012",
         "2012R2"
       ]


### PR DESCRIPTION
This commit prepares the module to be release as unsupported v0.1.0.

Note that the copyright changes were due to a previous copy and paste error.
This sole copyright holder for this module is Puppet, Inc.