### PR TITLE
(maint) Ensure Modulesync Ignores Rakefile

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -28,3 +28,7 @@ NOTICE:
 # already using master branch's version
 spec/spec_helper.rb:
   unmanaged: true
+
+# includes acceptance_tests rototiller rake task added with MODULES-3373
+Rakefile:
+  unmanaged: true


### PR DESCRIPTION
Updated .sync.yml to ignore the Rakefile due to rototiller tasks being added in MODULES-3373. This should be able to be abstracted and made reuseable across all modules by placing in puppetlabs_spec_helper or other shared library in future, this work is now tracked in MODULES-4529.