### PR TITLE
(MODULES-4601) Fail correctly when rototiller gem is not present

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -11,9 +11,11 @@ appveyor.yml:
       RUBY_VER: 23-x64
 Gemfile:
   optional:
+    'development':
+      - gem: 'rototiller'
+        version: '~> 1.0'
     ':system_tests':
       - gem: 'beaker-testmode_switcher'
-      - gem: 'rototiller'
 MAINTAINERS.md:
   maintainers:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
   gem 'fast_gettext', '1.1.0',              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem 'fast_gettext',                       :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem 'rainbow', '< 2.2.0',                 :require => false
+  gem 'rototiller', '~> 1.0',               :require => false
 end
 
 group :system_tests do
@@ -72,7 +73,6 @@ group :system_tests do
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
   gem 'beaker-testmode_switcher',                                                :require => false
-  gem 'rototiller',                                                              :require => false
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Rakefile
+++ b/Rakefile
@@ -48,8 +48,9 @@ begin
       env.default = "#{ENV['HOME']}/.ssh/id_rsa-acceptance"
     end
   end
-rescue LoadError
-  #Do nothing, rototiller only installed with system_tests group
+rescue LoadError => e
+  STDERR.puts "Unable to load rototiller:"
+  raise e
 end
 
 desc 'Generate pooler nodesets'


### PR DESCRIPTION
Added Rototiller version 1.0 to .sync file and Gemfile

Added a failure case when a rototiller task is run without rototiller gem installed.

Moved rototiller gem to Development group.