### PR TITLE
[maint] Fix development group naming in .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -11,7 +11,7 @@ appveyor.yml:
       RUBY_VER: 23-x64
 Gemfile:
   optional:
-    'development':
+    ':development':
       - gem: 'rototiller'
         version: '~> 1.0'
     ':system_tests':


### PR DESCRIPTION
This current .sync.yml produces an invalid Gemfile. The development group is specified in the Gemfile with a symbol and as such needs to be prefixed with a colon, like the :system_tests group below.