### PR TITLE
(maint) Handle non-https bindings better; add docs

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -138,9 +138,14 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
       end
       site['bindings'] = [] if site['bindings'].nil?
       site['bindings'].each do |binding|
-        ['protocol','bindinginformation','certificatehash','certificatestorename'].each do |setting|
-          binding[setting] = '' if binding[setting].nil?
-        end
+        # "The sslFlags attribute is only set when the protocol is https."
+        binding.delete('sslflags') unless binding['protocol'] == 'https'
+        # "The CertificateHash property is available only when the protocol
+        # identifier defined by the Protocol property is "https". An attempt to
+        # get or set the CertificateHash property for a binding with a protocol
+        # of "http" will raise an error."
+        binding.delete('certificatehash') unless binding['protocol'] == 'https'
+        binding.delete('certificatestorename') unless binding['protocol'] == 'https'
       end
 
       site_hash[:ensure]               = site['state'].downcase

--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -102,9 +102,6 @@ describe 'iis_application', :if => fact('kernelmajversion') == '6.3' do
               {
                 'bindinginformation'   => '*:80:modify',
                 'protocol'             => 'http',
-                'certificatestorename' => '',
-                'certificatehash'      => '',
-                'sslflags'             => 0,
               },
               {
                 'bindinginformation'   => '*:443:modify',

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -51,17 +51,11 @@ describe 'iis_site' do
               bindings             => [
                 {
                   'bindinginformation'   => '*:8080:',
-                  'certificatehash'      => '',
-                  'certificatestorename' => '',
                   'protocol'             => 'http',
-                  'sslflags'             => 0,
                 },
                 {
                   'bindinginformation'   => '*:8084:domain.test',
-                  'certificatehash'      => '',
-                  'certificatestorename' => '',
                   'protocol'             => 'http',
-                  'sslflags'             => 0,
                 },
               # {
               #   'bindinginformation'   => '10.32.126.39:443:domain.test',
@@ -337,17 +331,11 @@ describe 'iis_site' do
             bindings             => [
               {
                 'bindinginformation'   => '*:8080:',
-                'certificatehash'      => '',
-                'certificatestorename' => '',
                 'protocol'             => 'http',
-                'sslflags'             => 0,
               },
               {
                 'bindinginformation'   => '*:8084:domain.test',
-                'certificatehash'      => '',
-                'certificatestorename' => '',
                 'protocol'             => 'http',
-                'sslflags'             => 0,
               },
             ],
           }
@@ -363,10 +351,7 @@ describe 'iis_site' do
             bindings             => [
               {
                 'bindinginformation'   => '*:8081:',
-                'certificatehash'      => '',
-                'certificatestorename' => '',
                 'protocol'             => 'http',
-                'sslflags'             => 0,
               },
             ],
           }


### PR DESCRIPTION
The docs for sslflags and the two certificate attributes for a binding
describe the possible values and the fact that they are only needed when
protocol is the 'https' value.