### PR TITLE
(MODULES-4297) iis_site should autorequire the iis_application_pool

### DIFF
--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -273,6 +273,8 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
     end
   end
 
+  autorequire(:iis_application_pool) { self[:applicationpool] }
+
   validate do
     # TODO: These need validation
     # logperiod and logtruncatesize


### PR DESCRIPTION
Previously an IIS Site could be created out of order or even, in the absence of
a valid application pool.  This commit changes the iis_site resource so that it
autorequires the application pool and forces the correct resource graph to be
created.