### PR TITLE
(MODULES-5019) Prepare for 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
+## 2017-06-05 - Version 4.0.0
+
+### Summary
+
+This is the first supported release of the IIS module
+
+### Features
+
+- Added support for Windows Server 2008 R2 (IIS 7.5) ([MODULES-4484](https://tickets.puppetlabs.com/browse/MODULES-4484), [MODULES-4378](https://tickets.puppetlabs.com/browse/MODULES-4378))
+- `iis_site` autorequires a `iis_application_pool` resource ([MODULES-4297](https://tickets.puppetlabs.com/browse/MODULES-4297))
+- Added Types/Providers
+  - `iis_application` ([MODULES-3050](https://tickets.puppetlabs.com/browse/MODULES-3050))
+  - `iis_virtual_directory` ([MODULES-3053](https://tickets.puppetlabs.com/browse/MODULES-3053))
+- Added MIGRATION.md for migrating the IIS module from voxpupuli to puppetlabs
+
+### Bug Fixes
+
+- Removed the usage of APPCMD
+- Fixed minor typo in the iis_feature provider
+- Fix error message for SSL settings on HTTP binding ([MODULES-4762](https://tickets.puppetlabs.com/browse/MODULES-4762))
+- Update documentation for new types and providers ([MODULES-4752](https://tickets.puppetlabs.com/browse/MODULES-4752), [MODULES-4220](https://tickets.puppetlabs.com/browse/MODULES-4220), [MODULES-4564](https://tickets.puppetlabs.com/browse/MODULES-4564), [MODULES-4976](https://tickets.puppetlabs.com/browse/MODULES-4976))
+- Fix testing the `iis_feature` provider ([MODULES-4818](https://tickets.puppetlabs.com/browse/MODULES-4818))
+
+
 ## 2017-03-16 - Version 0.1.0
 
 ### Summary
+
 This is the initial, unsupported release with functionality to manage IIS application pools, sites and installation.
 
 ### Features
+
 - Added `iis_version` fact
 - Added Types/Providers
+  - `iis_application_pool` ([MODULES-4185](https://tickets.puppetlabs.com/browse/MODULES-4185), [MODULES-4220](https://tickets.puppetlabs.com/browse/MODULES-4220))
   - `iis_site` ([MODULES-3049](https://tickets.puppetlabs.com/browse/MODULES-3049), [MODULES-3887](https://tickets.puppetlabs.com/browse/MODULES-3887))
-  - `iis_application` ([MODULES-3050](https://tickets.puppetlabs.com/browse/MODULES-3050))
   - `iis_feature` ([MODULES-4434](https://tickets.puppetlabs.com/browse/MODULES-4434))

--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
   "name"        : "puppetlabs-iis",
-  "version"     : "0.1.0",
+  "version"     : "4.0.0",
   "author"      : "puppetlabs",
   "license"     : "Apache-2.0",
-  "summary"     : "Manage IIS for Windows Server 2008 and above. Maintain application sites, pools, virtual applications, and many other IIS settings.",
+  "summary"     : "Manage IIS for Windows Server 2008R2, 2012 and 2012R2. Maintain application sites, pools, installation, and many other IIS settings.",
   "source"      : "https://github.com/puppetlabs/puppetlabs-iis.git",
   "project_page": "https://github.com/puppetlabs/puppetlabs-iis",
   "issues_url"  : "https://tickets.puppet.com/browse/MODULES",
@@ -20,7 +20,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.5.0 <5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This commit prepares the module for the supported release of version 4.0.0.  The
large version bump is due to this module choosing a version number that is
higher than the puppet-iis module, which this module will eventually replace.