### PR TITLE
Adds support for IIS 10.0

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -12,7 +12,12 @@ Facter.add("iis_version") do
       HKLM.open(REG_PATH, ACCESS_TYPE) do |reg|
         iis_ver = reg[REG_KEY]
       end
-      iis_ver = iis_ver[8,3]
+     
+      if iis_ver.match(/^Version (\d+\.\d+)$/) then
+        iis_ver = $1
+      else
+        iis_ver = iis_ver[8,3] # Incorrectly reads 10.0 as 10.
+      end
     rescue
       iis_ver = ""
     end

--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5']
+  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application Pool provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5','8.0', '8.5']
+  confine    :iis_version     => ['7.5','8.0', '8.5', '10.0']
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -9,7 +9,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5','8.0','8.5']
+  confine    :iis_version     => ['7.5','8.0','8.5','10.0']
   confine    :operatingsystem => [:windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Virtual Directory provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5']
+  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:iis_application_pool) do
         raise ArgumentError, "A non-empty #{self.name.to_s} must be specified."
       end
       fail("#{self.name.to_s} should be less than 64 characters") unless value.length < 64
-      fail("#{self.name.to_s} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      fail("#{self.name.to_s} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s\.]+$/
     end
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -37,7 +37,7 @@ Puppet::Type.newtype(:iis_site) do
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s\.]+$/
     end
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -37,7 +37,7 @@ Puppet::Type.newtype(:iis_site) do
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s\.]+$/
     end
   end
 
@@ -57,7 +57,7 @@ Puppet::Type.newtype(:iis_site) do
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty applicationpool name must be specified."
       end
-      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s\.]+$/
     end
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -37,7 +37,7 @@ Puppet::Type.newtype(:iis_site) do
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s\.]+$/
+      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
     end
   end
 


### PR DESCRIPTION
Confines in the following providers have been extended to support 10.0 and tested against IIS 10.0 running on Windows Server 2016 Standard.

- `iis_application_pool`
- `iis_site`
- `iis_application`

Also fixes incorrect IIS version reporting in `iis_version.rb`.