### PR TITLE
(maint) Remove redundant ordering in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This complete example will create and configure an IIS Site called 'complete' in
 # Create Directory Structure
 file { 'c:\\inetpub\\complete':
   ensure => 'directory'
-} ->
+}
 file { 'c:\\inetpub\\complete_vdir':
   ensure => 'directory'
 }
@@ -77,13 +77,11 @@ acl { 'c:\\inetpub\\complete':
   permissions                => [
     {'identity' => 'IISCompleteGroup', 'rights' => ['read', 'execute']},
   ],
-  require => File['c:\\inetpub\\complete'],
 }
 acl { 'c:\\inetpub\\complete_vdir':
   permissions                => [
     {'identity' => 'IISCompleteGroup', 'rights' => ['read', 'execute']},
   ],
-  require => File['c:\\inetpub\\complete_vdir'],
 }
 
 # IIS Configuration


### PR DESCRIPTION
Prior to this, the README contained example usage that used `require`
and relationship arrows to order directories and acl resources. These
relationships do not need to be explicitly defined as Puppet and the acl
resource automatically make those relationshsips.

This commit removes the redundancy so that the example code is more
concise and simple.