### PR TITLE
(MODULES-5125) Update typo in iis_site acceptance tests

### DIFF
--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -327,7 +327,7 @@ describe 'iis_site' do
           @manifest = <<-HERE
           iis_site { '#{@site_name}':
             ensure          => 'started',
-            applicationpool => #{@pool_name},
+            applicationpool => '#{@pool_name}',
           }
           HERE
         end


### PR DESCRIPTION
The iis_site acceptance tests had a typo where the application_pool was being
set as a number instead of string.  This meant intermittently the tests would
fail when the Hex number had letters in it, instead of all numbers.  This then
caused puppet to throw an error as 123abc is not a number.  This commit encloses
the application pool name in quotes so that it is always interpretted as a
string.