### PR TITLE
Modules 5264 physicalpath regex does not match unc paths v2

### DIFF
--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -11,11 +11,6 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
 
   mk_resource_methods
 
-  def initialize(value={})
-    super(value)
-    @property_flush = {}
-  end
-
   def physicalpath=(value)
     @property_flush[:physicalpath] = value
   end
@@ -32,55 +27,62 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   end
 
   def create
-    check_paths
+    Puppet.debug "Creating #{@resource[:name]}"
+
+    verify_physicalpath
+
     if @resource[:virtual_directory]
-      args = Array.new
+      args = []
       args << "#{@resource[:virtual_directory]}"
       args << "-ApplicationPool #{@resource[:applicationpool].inspect}" if @resource[:applicationpool]
-      inst_cmd = "ConvertTo-WebApplication #{args.join(' ')} -Force -ErrorAction Stop"
+      cmd = "ConvertTo-WebApplication #{args.join(' ')} -Force -ErrorAction Stop"
     else
       fail "Error creating application: physicalpath is required to create" unless @resource[:physicalpath]
-      inst_cmd = self.class.ps_script_content('newapplication', @resource)
+      cmd = self.class.ps_script_content('newapplication', @resource)
     end
-    result = self.class.run(inst_cmd)
-    fail "Error creating application: #{result[:errormessage]}" unless result[:exitcode] == 0
-    fail "Error creating application: #{result[:errormessage]}" unless result[:errormessage].nil?
+    result = self.class.run(cmd)
+    Puppet.err "Error creating application: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
+
     @property_hash[:ensure] = :present
   end
 
-  def destroy
-    inst_cmd = "Remove-WebApplication -Site \"#{@resource[:sitename]}\" -Name \"#{@resource[:applicationname]}\" -ErrorAction Stop"
-    result   = self.class.run(inst_cmd)
-    @property_hash.clear
-    fail "Error destroying application: #{result[:errormessage]}" unless result[:exitcode] == 0
-    fail "Error destroying application: #{result[:errormessage]}" unless result[:errormessage].nil?
-  end
-
   def update
-    check_paths
-    inst_cmd = []
+    Puppet.debug "Updating #{@resource[:name]}"
 
-    inst_cmd << "$webApplication = Get-WebApplication -Site '#{resource[:sitename]}' -Name '#{resource[:applicationname]}'"
+    verify_physicalpath
+
+    cmd = []
+    cmd << "$webApplication = Get-WebApplication -Site '#{resource[:sitename]}' -Name '#{resource[:applicationname]}'"
     if @property_flush[:physicalpath]
-      #XXX Under what conditions would we have other paths?
-      inst_cmd << %{Set-WebConfigurationProperty -Filter "$($webApplication.ItemXPath)/virtualDirectory[@path='/']" -Name physicalPath -Value '#{@resource[:physicalpath]}' -ErrorAction Stop}
+      cmd << %{Set-WebConfigurationProperty -Filter "$($webApplication.ItemXPath)/virtualDirectory[@path='/']" -Name physicalPath -Value '#{@resource[:physicalpath]}' -ErrorAction Stop}
     end
-
     if @property_flush[:sslflags]
       flags = @property_flush[:sslflags].join(',')
-      inst_cmd << "Set-WebConfigurationProperty -Location '#{@resource[:sitename]}/#{@resource[:applicationname]}' -Filter 'system.webserver/security/access' -Name 'sslFlags' -Value '#{flags}' -ErrorAction Stop"
+      cmd << "Set-WebConfigurationProperty -Location '#{@resource[:sitename]}/#{@resource[:applicationname]}' -Filter 'system.webserver/security/access' -Name 'sslFlags' -Value '#{flags}' -ErrorAction Stop"
     end
-
     if @property_flush[:authenticationinfo]
       @property_flush[:authenticationinfo].each do |auth,enable|
-        inst_cmd << "Set-WebConfigurationProperty -Location '#{@resource[:sitename]}/#{@resource[:applicationname]}' -Filter 'system.webserver/security/authentication/#{auth}Authentication' -Name enabled -Value #{@property_flush[:authenticationinfo][auth]} -ErrorAction Stop"
+        cmd << "Set-WebConfigurationProperty -Location '#{@resource[:sitename]}/#{@resource[:applicationname]}' -Filter 'system.webserver/security/authentication/#{auth}Authentication' -Name enabled -Value #{@property_flush[:authenticationinfo][auth]} -ErrorAction Stop"
       end
     end
+    cmd = cmd.join("\n")
+    result = self.class.run(cmd)
+    Puppet.err "Error updating application: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
+  end
 
-    inst_cmd = inst_cmd.join("\n")
-    result   = self.class.run(inst_cmd)
-    fail "Error updating application: #{result[:errormessage]}" unless result[:exitcode] == 0
-    fail "Error updating application: #{result[:errormessage]}" unless result[:errormessage].nil?
+  def destroy
+    Puppet.debug "Destroying #{@resource[:name]}"
+
+    cmd = "Remove-WebApplication -Site \"#{@resource[:sitename]}\" -Name \"#{@resource[:applicationname]}\" -ErrorAction Stop"
+    result = self.class.run(cmd)
+    Puppet.err "Error destroying application: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
+
+    @property_hash.clear
+  end
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
   end
 
   def self.prefetch(resources)
@@ -93,25 +95,25 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   end
 
   def self.instances
-    inst_cmd = ps_script_content('getapps', @resource)
-    result   = run(inst_cmd)
+    cmd = ps_script_content('getapps', @resource)
+    result   = run(cmd)
     return [] if result.nil?
 
     app_json = self.parse_json_result(result[:stdout])
     return [] if app_json.nil?
 
     app_json = [app_json] if app_json.is_a?(Hash)
-    app_json.collect do |app|
+    return app_json.collect do |app|
       app_hash = {}
 
       app_hash[:ensure]             = :present
       app_hash[:name]               = "#{app['site']}\\#{app['name']}"
       app_hash[:applicationname]    = app['name']
-      app_hash[:sitename]           = app['site']
-      app_hash[:physicalpath]       = app['physicalpath']
       app_hash[:applicationpool]    = app['applicationpool']
-      app_hash[:sslflags]           = app['sslflags']
       app_hash[:authenticationinfo] = app['authenticationinfo']
+      app_hash[:physicalpath]       = app['physicalpath']
+      app_hash[:sitename]           = app['site']
+      app_hash[:sslflags]           = app['sslflags']
 
       new(app_hash)
     end
@@ -119,13 +121,15 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
 
   private
 
-  def check_paths
-    if @resource[:physicalpath] and ! File.exists?(@resource[:physicalpath])
-      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
+  def verify_physicalpath
+    if is_drive_path(@resource[:physicalpath])
+      if ! File.exists?(@resource[:physicalpath])
+        fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
+      end
     end
-    #XXX How do I check for IIS:\ path existence without shelling out to PS?
-    #if @resource[:virtual_directory] and ! File.exists?(@resource[:virtual_directory])
-    #  fail "virtual_directory doesn't exist: #{@resource[:virtual_directory]}"
-    #end
+  end
+
+  def is_drive_path(path)
+    return (path and path =~ /^.:(\/|\\)/)
   end
 end

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -17,24 +17,24 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
 
   def create
     Puppet.debug "Creating #{@resource[:name]}"
+
     inst_cmd = "New-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
     result   = self.class.run(inst_cmd)
-    Puppet.err "Error creating apppool: #{result[:errormessage]}" unless result[:exitcode] == 0
-    Puppet.err "Error creating apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
+    Puppet.err "Error creating apppool: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
+
     @resource[:ensure] = :present
   end
 
   def update
     Puppet.debug "Updating #{@resource[:name]}"
+ 
     cmd = []
-
     @resource.properties.select{|rp| rp.name != :ensure && rp.name != :state }.each do |property|
       property_name = iis_properties[property.name.to_s]
       Puppet.debug "Changing #{property_name} to #{property.value}"
       cmd << "Set-ItemProperty -Path 'IIS:\\AppPools\\#{@resource[:name]}' -Name '#{property_name}' -Value #{property.value};"
     end
-
-    if !@resource[:state].nil?
+    if ! @resource[:state].nil?
       Puppet.debug "Changing #{@resource[:name]} to #{@resource[:state]}"
       case @resource[:state].downcase
       when :stopped
@@ -43,21 +43,19 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
         cmd << "Start-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
       end
     end
-
     cmd = cmd.join
-    result   = self.class.run(cmd)
-    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless result[:exitcode] == 0
-    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
+    result = self.class.run(cmd)
+    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
   end
 
   def destroy
     Puppet.debug "Creating #{@resource[:name]}"
-    inst_cmd = "Remove-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
-    result   = self.class.run(inst_cmd)
-    Puppet.err "Error destroying apppool: #{result[:errormessage]}" unless result[:exitcode] == 0
-    Puppet.err "Error destroying apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
+
+    cmd = "Remove-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+    result   = self.class.run(cmd)
+    Puppet.err "Error destroying apppool: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
     
-    @resource[:ensure]  = :absent
+    @resource[:ensure] = :absent
   end
 
   def initialize(value={})

--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -1,6 +1,6 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_application) do
   @doc = "Manage an IIS applications."
@@ -33,24 +33,8 @@ Puppet::Type.newtype(:iis_application) do
     desc 'The name of the site for this IIS Web Application'
   end
 
-  newproperty(:physicalpath) do
-    desc 'The physical path to the IIS web application folder'
-    validate do |value|
-      if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty physicalpath must be specified."
-      end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
-    end
-  end
-
-  newproperty(:applicationpool) do
-    desc 'The name of an ApplicationPool for this IIS Web Application'
-    validate do |value|
-      if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty applicationpool name must be specified."
-      end
-      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
-    end
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
+    desc 'The physical path to the IIS virtual directory folder'
   end
 
   newparam(:virtual_directory) do

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -1,6 +1,7 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 require_relative '../../puppet_x/puppetlabs/iis/property/positive_integer'
+require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/timeformat'
 
 Puppet::Type.newtype(:iis_application_pool) do
@@ -48,7 +49,7 @@ Puppet::Type.newtype(:iis_application_pool) do
     end
   end
 
-  newproperty(:clr_config_file, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newproperty(:clr_config_file, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc "Specifies the .NET configuration file for the application pool"
   end
 

--- a/lib/puppet/type/iis_feature.rb
+++ b/lib/puppet/type/iis_feature.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_feature) do
   @doc = "Manage an IIS installed features."
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:iis_feature) do
     desc "Indicates whether to automatically install all managment tools for a given IIS feature"
   end
 
-  newparam(:source, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newparam(:source, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc "Optionally include a source path for the installation media for an IIS feature"
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -41,14 +42,8 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:physicalpath) do
-    desc 'The physical path to the IIS web site folder'
-    validate do |value|
-      if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty physicalpath must be specified."
-      end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
-    end
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
+    desc 'The physical path to the IIS virtual directory folder'
   end
 
   newproperty(:applicationpool) do
@@ -199,14 +194,11 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
     end
   end
 
-  newproperty(:logpath) do
-    desc 'Specifies the physical path to place the log file'
-    validate do |value|
-      if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty logpath must be specified."
-      end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
-    end
+  newproperty(:logpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
+    desc 'Specifies the physical path to the log file'
+    # The default value is %SystemDrive%\inetpub\logs\LogFiles.
+    # https://docs.microsoft.com/en-us/iis/configuration/system.applicationhost/sites/sitedefaults/logfile/
+    # Consider downgrading parent/validation to a PuppetX::PuppetLabs::IIS::String
   end
 
   newproperty(:logperiod) do

--- a/lib/puppet/type/iis_virtual_directory.rb
+++ b/lib/puppet/type/iis_virtual_directory.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_virtual_directory) do
   @doc = "Manage an IIS virtual directory."
@@ -31,14 +31,8 @@ Puppet::Type.newtype(:iis_virtual_directory) do
     end
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the IIS virtual directory folder'
-    validate do |value|
-      if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty physicalpath must be specified."
-      end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
-    end
   end
 
   autorequire(:iis_application) { self[:application] }

--- a/lib/puppet_x/puppetlabs/iis/property/path.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/path.rb
@@ -1,0 +1,17 @@
+module PuppetX
+  module PuppetLabs
+    module IIS
+      module Property
+        class Path < Puppet::Property
+          validate do |value|
+            if value.nil? or value.empty?
+              raise ArgumentError, "A non-empty #{self.name.to_s} must be specified."
+            end
+            # C:\directory or \\SERVER\share
+            fail("#{self.name.to_s} must be an absolute or UNC path, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\\\\[^\\]+\\[^\\]+/
+          end
+	end
+      end
+    end
+  end
+end


### PR DESCRIPTION
(MODULES-5264) IIS physicalpath regex doesn't match UNC paths  …

The first commit corrects the regex in the types:

  forward vs backslashes

The second commit:

  corrects tests of physicalpath in the providers

    remove File.exists tests of UNC paths

  provides a workaround for New-WebVirtualDirectory and Set-ItemProperty
  when setting physicalpath when the UNC path is not available

  corrects typo: in provider iis_virtual_directory

    "applicaiton"

  corrects :ensure instance attribute in iis_site provider

    "Notice: ... ensure changed '' to 'present'"

  normalizes arbitrarily unique code across providers