### PR TITLE
(MODULES-5264) IIS: handle UNC paths

### DIFF
--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -1,3 +1,4 @@
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_common')
 require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
@@ -32,7 +33,7 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   end
 
   def create
-    check_paths
+    verify_optional_physicalpath
     if @resource[:virtual_directory]
       args = Array.new
       args << "#{@resource[:virtual_directory]}"
@@ -57,7 +58,7 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   end
 
   def update
-    check_paths
+    verify_optional_physicalpath
     inst_cmd = []
 
     inst_cmd << "$webApplication = Get-WebApplication -Site '#{resource[:sitename]}' -Name '#{resource[:applicationname]}'"
@@ -115,17 +116,5 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
 
       new(app_hash)
     end
-  end
-
-  private
-
-  def check_paths
-    if @resource[:physicalpath] and ! File.exists?(@resource[:physicalpath])
-      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
-    end
-    #XXX How do I check for IIS:\ path existence without shelling out to PS?
-    #if @resource[:virtual_directory] and ! File.exists?(@resource[:virtual_directory])
-    #  fail "virtual_directory doesn't exist: #{@resource[:virtual_directory]}"
-    #end
   end
 end

--- a/lib/puppet/provider/iis_common.rb
+++ b/lib/puppet/provider/iis_common.rb
@@ -1,0 +1,29 @@
+def verify_physicalpath
+  if @resource[:physicalpath].nil? or @resource[:physicalpath].empty?
+    fail "physicalpath is a required parameter"
+  end
+  if is_drive_path(@resource[:physicalpath])
+    if ! File.exists?(@resource[:physicalpath])
+      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
+    end    
+  end
+end
+
+def verify_optional_physicalpath
+  if @resource[:physicalpath].nil? or @resource[:physicalpath].empty?
+    return
+  end
+  if is_drive_path(@resource[:physicalpath])
+    if ! File.exists?(@resource[:physicalpath])
+      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
+    end    
+  end
+end
+
+def is_drive_path(path)
+  return (path =~ /^.:(\/|\\)/)
+end
+
+def is_unc_path(path)
+  return (path =~ /^\\\\[^\\]+\\[^\\]+/)
+end

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -1,3 +1,4 @@
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_common')
 require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 # When writing IIS PowerShell code for any of the methods below
@@ -18,6 +19,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
   mk_resource_methods
 
   def create
+    verify_physicalpath
+
     cmd = []
 
     cmd << self.class.ps_script_content('_newwebsite', @resource)
@@ -33,6 +36,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
   end
 
   def update
+    verify_physicalpath
+
     cmd = []
 
     cmd << self.class.ps_script_content('_setwebsite', @resource)
@@ -148,7 +153,12 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
         binding.delete('certificatestorename') unless binding['protocol'] == 'https'
       end
 
-      site_hash[:ensure]               = site['state'].downcase
+      if site['state'] == ''
+        site_hash[:ensure]             = :present
+      else
+        site_hash[:ensure]             = site['state'].downcase
+      end
+
       site_hash[:name]                 = site['name']
       site_hash[:physicalpath]         = site['physicalpath']
       site_hash[:applicationpool]      = site['applicationpool']

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -1,3 +1,4 @@
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_common')
 require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
@@ -18,47 +19,71 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
   def create
     Puppet.debug "Creating #{@resource[:name]}"
 
-    if @resource[:physicalpath].nil?
-      fail "physicalpath is a required paramter to create a iis virtual directory"
+    verify_physicalpath
+
+    # New-WebVirtualDirectory fails when PhysicalPath is a UNC path that is not available:
+    #   "Parameter 'PhysicalPath' should point to existing path."
+
+    if is_drive_path(@resource[:physicalpath])
+      cmd = []
+      cmd << "New-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
+      cmd << "-Site \"#{@resource[:sitename]}\" " if @resource[:sitename]
+      cmd << "-Application \"#{@resource[:application]}\" " if @resource[:application]
+      cmd << "-PhysicalPath \"#{@resource[:physicalpath]}\" "
+      cmd << "-ErrorAction Stop"
+      cmd = cmd.join
+
+      result   = self.class.run(cmd)
+      Puppet.err "Error creating virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
+      @resource[:ensure] = :present
     end
+    if is_unc_path(@resource[:physicalpath])
+      cmd = []
+      cmd << "New-Item -type VirtualDirectory \"IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}\" "
+      cmd << "-Application \"#{@resource[:application]}\" " if @resource[:application]
+      cmd << "-PhysicalPath \"#{@resource[:physicalpath]}\" "
+      cmd = cmd.join
 
-    if @resource[:physicalpath] and ! File.exists?(@resource[:physicalpath])
-      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
+      result = self.class.run(cmd)
+      Puppet.err "Error creating virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
+      @resource[:ensure] = :present
     end
-
-    cmd = []
-    cmd << "New-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
-    cmd << "-Site \"#{@resource[:sitename]}\" " if @resource[:sitename]
-    cmd << "-Application \"#{@resource[:application]}\" " if @resource[:application]
-    cmd << "-PhysicalPath \"#{@resource[:physicalpath]}\" " if @resource[:physicalpath]
-    cmd << "-ErrorAction Stop"
-    cmd = cmd.join
-
-    result   = self.class.run(cmd)
-    Puppet.err "Error creating virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
-    @resource[:ensure] = :present
   end
 
   def update
+    # WORKAROUND: update() is called after destroy() by flush() in ../iis_powershell.rb
+    # New-Item -Force recreates the VirtualDirectory unless we return early.
+    return if (@resource[:ensure] == :absent)
+    
     Puppet.debug "Updating #{@resource[:name]}"
 
-    if @resource[:physicalpath] and ! File.exists?(@resource[:physicalpath])
-      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
+    verify_physicalpath
+
+    # Set-ItemProperty fails when PhysicalPath is a UNC path that is not available:
+    #   "Parameter 'PhysicalPath' should point to existing path."
+
+    if is_drive_path(@resource[:physicalpath])
+      cmd = "Set-ItemProperty 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'PhysicalPath' -Value '#{@resource[:physicalpath]}'"
+      result = self.class.run(cmd)
+      Puppet.err "Error updating virtual directory: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
+    end
+    if is_unc_path(@resource[:physicalpath])
+      cmd = "Set-Item 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -type VirtualDirectory -PhysicalPath '#{@resource[:physicalpath]}' -Force"
+      result = self.class.run(cmd)
+      Puppet.err "Error updating virtual directory: #{result[:errormessage]}" unless (result[:exitcode] == 0 && result[:errormessage].nil?)
     end
 
     cmd = []
-
-    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'site' -Value '#{@resource[:sitename]}';" if @resource[:sitename]
-    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'physicalpath' -Value '#{@resource[:physicalpath]}';" if @resource[:physicalpath]
-    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'application' -Value '#{@resource[:application]}';" if @resource[:application]
-
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'Site' -Value '#{@resource[:sitename]}';" if @resource[:sitename]
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'Application' -Value '#{@resource[:application]}';" if @resource[:application]
     cmd = cmd.join
+
     result   = self.class.run(cmd)
     Puppet.err "Error updating virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
   end
 
   def destroy
-    Puppet.debug "Creating #{@resource[:name]}"
+    Puppet.debug "Destroying #{@resource[:name]}"
     cmd = []
     cmd << "Remove-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
     cmd << "-Site \"#{@resource[:sitename]}\" " if @resource[:sitename]
@@ -106,11 +131,10 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
       virt_dir_hash[:ensure]       = :present
       virt_dir_hash[:name]         = virt_dir['name']
       virt_dir_hash[:physicalpath] = virt_dir['physicalpath']
-      virt_dir_hash[:applicaiton]  = virt_dir['applicaiton']
+      virt_dir_hash[:application]  = virt_dir['application']
       virt_dir_hash[:sitename]     = virt_dir['sitename']
 
       new(virt_dir_hash)
     end
   end
-  
 end

--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -1,6 +1,7 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_application) do
   @doc = "Manage an IIS applications."
@@ -33,13 +34,12 @@ Puppet::Type.newtype(:iis_application) do
     desc 'The name of the site for this IIS Web Application'
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the IIS web application folder'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty physicalpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
     end
   end
 

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -1,5 +1,6 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 require_relative '../../puppet_x/puppetlabs/iis/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/iis/property/timeformat'
 
@@ -48,7 +49,7 @@ Puppet::Type.newtype(:iis_application_pool) do
     end
   end
 
-  newproperty(:clr_config_file, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newproperty(:clr_config_file, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc "Specifies the .NET configuration file for the application pool"
   end
 

--- a/lib/puppet/type/iis_feature.rb
+++ b/lib/puppet/type/iis_feature.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_feature) do
   @doc = "Manage an IIS installed features."
@@ -18,14 +18,14 @@ Puppet::Type.newtype(:iis_feature) do
   end
 
   newparam(:restart, :boolean => true) do
-    desc "Indicates whether to allow a restart if the IIS feature installationrequests one"
+    desc "Indicates whether to allow a restart if the IIS feature installation requests one"
   end
 
   newparam(:include_management_tools, :boolean => true) do
     desc "Indicates whether to automatically install all managment tools for a given IIS feature"
   end
 
-  newparam(:source, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newparam(:source, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc "Optionally include a source path for the installation media for an IIS feature"
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,4 +1,6 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
+require_relative '../../puppet_x/puppetlabs/iis/property/string'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -41,13 +43,12 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the IIS web site folder'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty physicalpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
     end
   end
 
@@ -199,13 +200,12 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
     end
   end
 
-  newproperty(:logpath) do
-    desc 'Specifies the physical path to place the log file'
+  newproperty(:logpath, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc 'Specifies the path to the log files'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty logpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
     end
   end
 

--- a/lib/puppet/type/iis_virtual_directory.rb
+++ b/lib/puppet/type/iis_virtual_directory.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_virtual_directory) do
   @doc = "Manage an IIS virtual directory."
@@ -11,6 +11,11 @@ Puppet::Type.newtype(:iis_virtual_directory) do
 
   newparam(:name, :namevar => true) do
     desc 'The name of the virtual directory to manage'
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty name must be specified."
+      end
+    end
   end
 
   newproperty(:sitename) do
@@ -31,13 +36,12 @@ Puppet::Type.newtype(:iis_virtual_directory) do
     end
   end
 
-  newproperty(:physicalpath) do
-    desc 'The physical path to the IIS virtual directory folder'
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
+    desc 'The physical path to the virtual directory'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty physicalpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
     end
   end
 

--- a/lib/puppet_x/puppetlabs/iis/property/path.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/path.rb
@@ -1,0 +1,18 @@
+module PuppetX
+  module PuppetLabs
+    module IIS
+      module Property
+        class Path < Puppet::Property
+          validate do |value|
+            if value
+              unless value =~ /^.:(\/|\\)/ or value =~ /^\\\\[^\\]+\\[^\\]+/
+                # (c:\directory or c:/directory) or \\server\share
+                fail("#{self.name.to_s} should be a Path (Absolute or UNC) not '#{value}'")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/matchers/type_provider_interface.rb
+++ b/spec/support/matchers/type_provider_interface.rb
@@ -1,4 +1,17 @@
 
+RSpec::Matchers.define :require_path_for do |property|
+  match do |type_class|
+    config = {name: 'name'}
+    config[property] = 2
+    expect do
+      type_class.new(config)
+    end.to raise_error(Puppet::Error, /#{property} should be a Path/)
+  end
+  failure_message do |type_class|
+    "#{type_class} should require #{property} to be a Path"
+  end
+end
+
 RSpec::Matchers.define :require_string_for do |property|
   match do |type_class|
     config = {name: 'name'}

--- a/spec/unit/puppet/type/iis_application_pool_spec.rb
+++ b/spec/unit/puppet/type/iis_application_pool_spec.rb
@@ -113,7 +113,6 @@ describe 'iis_application_pool' do
   
   [
     :name,
-    :clr_config_file,
     :managed_runtime_loader,
     :log_event_on_process_model,
     :orphan_action_exe,
@@ -125,6 +124,14 @@ describe 'iis_application_pool' do
   ].each do |property|
     it "should require #{property} to be a string" do
       expect(type_class).to require_string_for(property)
+    end
+  end
+
+  [
+    :clr_config_file,
+  ].each do |property|
+    it "should require #{property} to be a path" do
+      expect(type_class).to require_path_for(property)
     end
   end
 

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -6,8 +6,6 @@ describe Puppet::Type.type(:iis_site) do
   let(:resource) { described_class.new(:name => "iis_site") }
   subject { resource }
 
-  it { is_expected.to be_a_kind_of Puppet::Type::Iis_site }
-
   describe "parameter :name" do
     subject { resource.parameters[:name] }
 
@@ -38,7 +36,6 @@ describe Puppet::Type.type(:iis_site) do
     end
   end
 
-  # TODO: fix tests below
   context "parameter :physicalpath" do
     it "should not allow nil" do
       expect {
@@ -49,12 +46,12 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:physicalpath] = ''
-      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified./)
+      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified/)
     end
 
-    it "should accept any string value" do
-      resource[:physicalpath] = "c:/thisstring-location/value/somefile.txt"
-      resource[:physicalpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    it "should accept forward-slash and backslash paths" do
+      resource[:physicalpath] = "c:/directory/subdirectory"
+      resource[:physicalpath] = "c:\\directory\\subdirectory"
     end
   end
 
@@ -300,7 +297,7 @@ describe Puppet::Type.type(:iis_site) do
       }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Valid values are W3C, IIS, NCSA/)
     end
   end
-
+  
   context "parameter :logpath" do
     it "should not allow nil" do
       expect {
@@ -311,12 +308,12 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:logpath] = ''
-      }.to raise_error(Puppet::Error, /A non-empty logpath must be specified./)
+      }.to raise_error(Puppet::Error, /A non-empty logpath must be specified/)
     end
 
-    it "should accept any string value" do
-      resource[:logpath] = "c:/thisstring-location/value/somefile.txt"
-      resource[:logpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    it "should accept forward-slash and backslash paths" do
+      resource[:logpath] = "c:/directory/subdirectory"
+      resource[:logpath] = "c:\\directory\\subdirectory"
     end
   end
 

--- a/spec/unit/puppet/type/iis_virtual_directory_spec.rb
+++ b/spec/unit/puppet/type/iis_virtual_directory_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'iis_virtual_directory' do
+describe Puppet::Type.type(:iis_virtual_directory) do
   let(:type_class) { Puppet::Type.type(:iis_virtual_directory) }
 
   let :params do
@@ -16,21 +16,6 @@ describe 'iis_virtual_directory' do
       :application,
       :physicalpath
     ]
-  end
-
-  let :minimal_config do
-    {
-      name: 'Some Virtual Directory',
-    }
-  end
-
-  let :optional_config do
-    {
-    }
-  end
-
-  let :default_config do
-     minimal_config.merge(optional_config)
   end
 
   it 'should have expected properties' do
@@ -49,24 +34,75 @@ describe 'iis_virtual_directory' do
     expect(params + [:provider]).to include(*type_class.parameters)
   end
 
-  it 'should default ensure to present' do
-    pool = type_class.new(
-      name: 'foo',
-    )
-    expect(pool[:ensure]).to eq(:present)
+  let(:resource) { described_class.new(:name => "iis_virtual_directory") }
+  subject { resource }
+
+  describe "parameter :name" do
+    subject { resource.parameters[:name] }
+
+    it { is_expected.to be_isnamevar }
+
+    it "should not allow nil" do
+      expect {
+        resource[:name] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for name/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:name] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty name must be specified/)
+    end
   end
 
-  context 'with a minimal set of properties' do
-    let :config do
-      minimal_config
+  describe "parameter :sitename" do
+    subject { resource.parameters[:name] }
+
+    it "should not allow nil" do
+      expect {
+        resource[:sitename] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for sitename/)
     end
 
-    let :virtual_directory do
-      type_class.new(config)
+    it "should not allow empty" do
+      expect {
+        resource[:sitename] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty sitename must be specified/)
+    end
+  end
+
+  describe "parameter :application" do
+    subject { resource.parameters[:name] }
+
+    it "should not allow nil" do
+      expect {
+        resource[:application] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for application/)
     end
 
-    it 'should be valid' do
-      expect { virtual_directory }.not_to raise_error
+    it "should not allow empty" do
+      expect {
+        resource[:application] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty application must be specified/)
+    end
+  end
+
+  context "parameter :physicalpath" do
+    it "should not allow nil" do
+      expect {
+        resource[:physicalpath] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for physicalpath/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:physicalpath] = ''
+      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified/)
+    end
+
+    it "should accept forward-slash and backslash paths" do
+      resource[:physicalpath] = "c:/directory/subdirectory"
+      resource[:physicalpath] = "c:\\directory\\subdirectory"
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, the IIS module:

included regular expressions that failed to a match a UNC paths
attempted to use File.exists? to test a UNC path
failed to set iis_virtual_directory physicalpath to a UNC path

Also, these issues interfered with development and testing:

ran iis_virtual_directory update() after destroy()
failed to set the iis_site :ensure attribute to :present
failed to set the iis_virtual_directory :application attribute