### PR TITLE
(MODULES-5344) iis_virtual_directory handle slashes in name

### DIFF
--- a/lib/puppet/provider/templates/webadministration/_getvirtualdirectories.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getvirtualdirectories.ps1.erb
@@ -1,24 +1,27 @@
-Get-WebVirtualDirectory | % {
-  $path         = $_.Path
-  $physicalpath =  [string]$_.PhysicalPath
-
-  if($path -match "\/.*\/.*"){
-    $application = $_.Path.Split("/")[1]
-    $name        = $_.Path.Split("/")[2]
-  }else{
-    $name        = $_.Path.Trim("/")
-    $application = "/"
+Get-WebVirtualDirectory | ForEach-Object {
+  $physicalpath = [string]$_.PhysicalPath
+  
+  $name = [string]$_.Path
+  $name = $name -Replace "^/", ''
+  $name = $name -Replace "/",  '\'
+  
+  if ($_.ItemXPath -Match "application\[\@path\=(.*?)\]") {
+    $application = $matches[1].Replace("'", '')
+  } else {
+    $application = '/'
   }
-
-  if($_.ItemXPath -match ".*name\=(.*) and @id=(.*)"){
-    $site = $matches[1].Replace("'","")
+  
+  if ($_.ItemXPath -Match "site\[\@name\=(.*?) and") {
+    $sitename = $matches[1].Replace("'", '')
+  } else {
+    $sitename = ''
   }
 
   New-Object -TypeName PSObject -Property @{
     name         = $name
     physicalpath = $physicalpath
     application  = $application
-    sitename     = $site
+    sitename     = $sitename
   }
 
 } | ConvertTo-Json -Depth 10

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -97,6 +97,48 @@ describe 'iis_virtual_directory' do
           remove_vdir(@virt_dir_name)
         end
       end
+
+      context 'name allows slashes' do
+        before(:all) do
+          @virt_dir_name = "#{SecureRandom.hex(10)}"
+          @manifest  = <<-HERE
+          file { 'c:\\inetpub\\test_site':
+            ensure          => 'present',
+          }->
+          iis_site { "test_site":
+            name            => "test_site",
+            ensure          => 'present',
+            physicalpath    => 'c:\\inetpub\\test_site',
+            applicationpool => 'DefaultApplicationPool',
+          }
+
+          file { 'c:\\inetpub\\test_vdir':
+            ensure       => 'present',
+          }->
+          iis_virtual_directory{ "test_vdir":
+            ensure       => 'present',
+            sitename     => "test_site",
+            physicalpath => 'c:\\inetpub\\test_vdir',
+          }
+
+          file { 'c:\\inetpub\\deeper':
+            ensure       => 'present',
+          }->
+          iis_virtual_directory { 'test_vdir\deeper':
+            name         => 'test_vdir\deeper',
+            ensure	     => 'present',
+            sitename     => 'test_site',
+            physicalpath => 'c:\\inetpub\\deeper',
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        after(:all) do
+          remove_vdir(@virt_dir_name)
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -43,6 +43,37 @@ describe 'iis_virtual_directory' do
         remove_vdir(@virt_dir_name)
       end
     end
+    
+    context 'name allows slashes' do
+      context 'simple case' do
+        before(:all) do
+          @virt_dir_name = "#{SecureRandom.hex(10)}"
+          create_path('c:\inetpub\test_site')
+          create_path('c:\inetpub\test_vdir')
+          create_path('c:\inetpub\deeper')
+          create_site(@site_name, true)
+          @manifest  = <<-HERE
+          iis_virtual_directory{ "test_vdir":
+            ensure       => 'present',
+            sitename     => "#{@site_name}",
+            physicalpath => 'c:\\inetpub\\test_vdir',
+          }->
+          iis_virtual_directory { 'test_vdir\deeper':
+            name         => 'test_vdir\deeper',
+            ensure	     => 'present',
+            sitename     => '#{@site_name}',
+            physicalpath => 'c:\\inetpub\\deeper',
+          }
+          HERE
+        end
+        
+        it_behaves_like 'an idempotent resource'
+
+        after(:all) do
+          remove_vdir(@virt_dir_name)
+        end
+      end
+    end
 
     context 'with invalid' do
       context 'physicalpath parameter defined' do
@@ -92,48 +123,6 @@ describe 'iis_virtual_directory' do
 
           puppet_resource_should_show('ensure', 'absent')
         end
-
-        after(:all) do
-          remove_vdir(@virt_dir_name)
-        end
-      end
-
-      context 'name allows slashes' do
-        before(:all) do
-          @virt_dir_name = "#{SecureRandom.hex(10)}"
-          @manifest  = <<-HERE
-          file { 'c:\\inetpub\\test_site':
-            ensure          => 'present',
-          }->
-          iis_site { "test_site":
-            name            => "test_site",
-            ensure          => 'present',
-            physicalpath    => 'c:\\inetpub\\test_site',
-            applicationpool => 'DefaultApplicationPool',
-          }
-
-          file { 'c:\\inetpub\\test_vdir':
-            ensure       => 'present',
-          }->
-          iis_virtual_directory{ "test_vdir":
-            ensure       => 'present',
-            sitename     => "test_site",
-            physicalpath => 'c:\\inetpub\\test_vdir',
-          }
-
-          file { 'c:\\inetpub\\deeper':
-            ensure       => 'present',
-          }->
-          iis_virtual_directory { 'test_vdir\deeper':
-            name         => 'test_vdir\deeper',
-            ensure	     => 'present',
-            sitename     => 'test_site',
-            physicalpath => 'c:\\inetpub\\deeper',
-          }
-          HERE
-        end
-
-        it_behaves_like 'an idempotent resource'
 
         after(:all) do
           remove_vdir(@virt_dir_name)

--- a/spec/unit/puppet/provider/iis_virtual_directory/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_virtual_directory/webadministration_spec.rb
@@ -1,32 +1,70 @@
 require 'spec_helper'
+require 'puppet/type'
+require 'puppet/type/iis_virtual_directory'
 
-provider_class = Puppet::Type.type(:iis_virtual_directory).provider(:webadministration)
+describe Puppet::Type.type(:iis_virtual_directory) do
+  let(:resource) { described_class.new(:name => "iis_virtual_directory") }
+  subject { resource }
 
-describe provider_class do
-  let(:facts) {{
-    iis_version: '8.0',
-    operatingsystem: 'Windows'
-  }}
+  it { is_expected.to be_a_kind_of Puppet::Type::Iis_virtual_directory }
 
-  let(:resource) {
-    result = Puppet::Type.type(:iis_virtual_directory).new(:name => "iis_virtual_directory")
-    result.provider = subject
-    result
-  }
+  describe "parameter :name" do
+    subject { resource.parameters[:name] }
 
-  it 'should be an instance of the correct provider' do
-    expect(resource.provider).to be_an_instance_of Puppet::Type::Iis_virtual_directory::ProviderWebadministration
-  end
+    it { is_expected.to be_isnamevar }
 
-  [:name].each do |method|
-    it "should respond to the class method #{method}" do
-      expect(provider_class).to respond_to(method)
+    [ 'value', 'value\with\slashes', '0123456789_-' ].each do |value|
+      it "should accept '#{value}'" do
+        expect { resource[:name] = value }.not_to raise_error
+      end
     end
   end
 
-  [:exists?, :create, :destroy, :update].each do |method|
-    it "should respond to the instance method #{method}" do
-      expect(provider_class.new).to respond_to(method)
+  context "parameter :sitename" do
+    it "should not allow nil" do
+      expect {
+        resource[:sitename] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for sitename/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:sitename] = ''
+      }.to raise_error(Puppet::Error, /A non-empty sitename must be specified/)
     end
   end
+
+  context "parameter :application" do
+    it "should not allow nil" do
+      expect {
+        resource[:application] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for application/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:application] = ''
+      }.to raise_error(Puppet::Error, /A non-empty application must be specified/)
+    end
+  end
+
+  context "parameter :physicalpath" do
+    it "should not allow nil" do
+      expect {
+        resource[:physicalpath] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for physicalpath/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:physicalpath] = ''
+      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified/)
+    end
+
+    it "should accept forward and back slashes" do
+      resource[:physicalpath] = "c:/thisstring-location/value/somefile.txt"
+      resource[:physicalpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    end
+  end
+
 end


### PR DESCRIPTION
Prior to this commit, iis_virtual_directory was not idempotent when the name
attribute contained slashes.

iis_virtual_directory uses the PowerShell New-WebVirtualDirectory command.
New-VirtualDirectory uses Name to set Path, and Path may contain slashes.

With this commit, iis_virtual_directory is idempotent when name contains
backward slashes. Due to the behaviour of Get-Item and Get-WebVirtualDirectory,
name may not contain forward slashes, as documented in the associated ticket.