### PR TITLE
(MODULES-5169) iis_application_pool not idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,8 +433,11 @@ Specifies that the worker process should be recycled after a specified amount of
 
 #### `restart_schedule`
 
-Specifies the time intervals between restarts of worker processes in an application pool.
+Specifies the specific times in a 24-hour period that the worker process should be recycled.
 
+Accepts an array of formatted times: `['06:30:00', '12:30:00', '18:30:00']`
+
+Times should be between 00:00:00 and 23:59:59 seconds inclusive, with a granularity of 60 seconds.
 
 ### iis_feature
 

--- a/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
@@ -55,6 +55,6 @@ Get-WebConfiguration -Filter '/system.applicationHost/applicationPools/add' | % 
     restart_private_memory_limit       = [string]$_.recycling.periodicrestart.privatememory
     restart_requests_limit             = [string]$_.recycling.periodicrestart.requests
     restart_time_limit                 = [string]$_.recycling.periodicrestart.time
-    restart_schedule                   = [string]$_.recycling.periodicrestart.schedule.collection.value -split ' '
+    restart_schedule                   = [string]$_.recycling.periodicrestart.schedule.collection.value
   }
 } | ConvertTo-Json -Depth 10

--- a/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getapppools.ps1.erb
@@ -35,24 +35,26 @@ Get-WebConfiguration -Filter '/system.applicationHost/applicationPools/add' | % 
     set_profile_environment    = [string]$_.processmodel.setProfileEnvironment
     shutdown_time_limit        = [string]$_.processmodel.shutdownTimeLimit
     startup_time_limit         = [string]$_.processmodel.startupTimeLimit
-    orphan_action_exe          = [string]$_.processmodel.orphanactionexe
-    orphan_action_params       = [string]$_.processmodel.orphanactionparams
-    orphan_worker_process      = [string]$_.processmodel.orphanworkerprocess
-    
-    load_balancer_capabilities        = [string]$_.loadbalancercapabilities
-    rapid_fail_protection             = [string]$_.rapidfailprotection
-    rapid_fail_protection_interval    = [string]$_.rapidfailprotectioninterval
-    rapid_fail_protection_max_crashes = [string]$_.rapidfailprotectionmaxcrashes
-    auto_shutdown_exe                 = [string]$_.autoshutdownexe
-    auto_shutdown_params              = [string]$_.autoshutdownparams
-    
-    disallow_overlapping_rotation      = [string]$_.disallowoverlappingrotation
-    disallow_rotation_on_config_change = [string]$_.disallowrotationonconfigchange
-    log_event_on_recycle               = [string]$_.logeventonrecycle
-    restart_memory_limit               = [string]$_.restartmemorylimit
-    restart_private_memory_limit       = [string]$_.restartprivatememorylimit
-    restart_requests_limit             = [string]$_.restartrequestslimit
-    restart_time_limit                 = [string]$_.restarttimelimit
-    restart_schedule                   = [string]$_.restartschedule
+    user_name                  = [string]$_.processmodel.username
+    password                   = [string]$_.processmodel.password
+
+    orphan_action_exe                 = [string]$_.failure.orphanactionexe
+    orphan_action_params              = [string]$_.failure.orphanactionparams
+    orphan_worker_process             = [string]$_.failure.orphanworkerprocess
+    load_balancer_capabilities        = [string]$_.failure.loadbalancercapabilities
+    rapid_fail_protection             = [string]$_.failure.rapidfailprotection
+    rapid_fail_protection_interval    = [string]$_.failure.rapidfailprotectioninterval
+    rapid_fail_protection_max_crashes = [string]$_.failure.rapidfailprotectionmaxcrashes
+    auto_shutdown_exe                 = [string]$_.failure.autoshutdownexe
+    auto_shutdown_params              = [string]$_.failure.autoshutdownparams
+
+    disallow_overlapping_rotation      = [string]$_.recycling.disallowoverlappingrotation
+    disallow_rotation_on_config_change = [string]$_.recycling.disallowrotationonconfigchange
+    log_event_on_recycle               = [string]$_.recycling.logeventonrecycle
+    restart_memory_limit               = [string]$_.recycling.periodicrestart.memory
+    restart_private_memory_limit       = [string]$_.recycling.periodicrestart.privatememory
+    restart_requests_limit             = [string]$_.recycling.periodicrestart.requests
+    restart_time_limit                 = [string]$_.recycling.periodicrestart.time
+    restart_schedule                   = [string]$_.recycling.periodicrestart.schedule.collection.value -split ' '
   }
 } | ConvertTo-Json -Depth 10

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -365,10 +365,15 @@ A value of '0' specifies that IIS runs the same number of worker processes as th
     desc "Specifies that the worker process should be recycled after a specified amount of time has elapsed."
   end
 
-  newproperty(:restart_schedule, :parent => PuppetX::PuppetLabs::IIS::Property::TimeFormat) do
-    desc "specifies the time intervals between restarts of worker processes in an application pool."
+  newproperty(:restart_schedule, :array_matching => :all) do
+    desc "Specifies the specific times in a 24-hour period that the worker process should be recycled."
+    validate do |value|
+      fail "#{self.name.to_s} values should be between 00:00:00 and 23:59:59 seconds inclusive, with a granularity of 60 seconds." unless value =~ /^\d\d:\d\d:00$/
+    end
+    def should_to_s(newvalue)
+      return newvalue
+    end
   end
-
 
   def munge_boolean(value)
     case value

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -36,7 +36,10 @@ Puppet::Type.newtype(:iis_application_pool) do
 
   newproperty(:state) do
     desc "The state of the ApplicationPool. By default, a newly created application pool will be started"
-    newvalues(:Started,:Stopped,:started,:stopped)
+    newvalues(:started, :stopped)
+
+    aliasvalue(:Stopped, :stopped)
+    aliasvalue(:Started, :started)
   end
 
   newproperty(:auto_start, :boolean => true) do

--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -203,4 +203,35 @@ describe 'iis_application_pool' do
       puppet_resource_should_show('ensure', 'absent')
     end
   end
+
+  context 'when application pool restart_memory_limit set' do
+    before(:all) do
+      @pool_name = "#{SecureRandom.hex(10)}"
+      create_app_pool(@pool_name)
+      stop_app_pool(@pool_name)
+      @manifest = <<-HERE
+          iis_application_pool { '#{@pool_name}':
+            ensure               => 'present',
+            state                => 'Started',
+            restart_memory_limit => '3500000',
+          }
+      HERE
+    end
+
+    it_behaves_like 'an idempotent resource'
+
+    context 'when puppet resource is run' do
+      before(:all) do
+        @result = resource('iis_application_pool', @pool_name)
+      end
+
+      puppet_resource_should_show('ensure', 'present')
+      puppet_resource_should_show('state', 'Started')
+      puppet_resource_should_show('restart_memory_limit', '3500000')
+    end
+
+    after(:all){
+      remove_app_pool(@pool_name)
+    }
+  end
 end

--- a/spec/unit/puppet/type/iis_application_pool_spec.rb
+++ b/spec/unit/puppet/type/iis_application_pool_spec.rb
@@ -160,7 +160,6 @@ describe 'iis_application_pool' do
     {:startup_time_limit => "00:00:00"},
     {:rapid_fail_protection_interval => "00:00:00"},
     {:restart_time_limit => "00:00:00"},
-    {:restart_schedule => "00:00:00"},
   ].each do |property|
     prop = property.keys[0]
     upper_limit = property[property.keys[0]]
@@ -210,6 +209,41 @@ describe 'iis_application_pool' do
       end
     end
 
+  end
+
+  context 'parameter :restart_schedule' do
+    it 'should accept a formatted time' do
+      pool = type_class.new(
+        name: 'foo',
+        restart_schedule: '00:00:00',
+      )
+      expect(pool[:restart_schedule]).to eq(['00:00:00'])
+    end
+    it 'should accept an array of formatted times' do
+      pool = type_class.new(
+        name: 'foo',
+        restart_schedule: ['00:00:00'],
+      )
+      expect(pool[:restart_schedule]).to eq(['00:00:00'])
+    end
+    it 'should reject a value that is not a formatted time' do
+      expect do
+        config = {
+          name: 'foo',
+          restart_schedule: 'bottle',
+        }
+        type_class.new(config)
+      end.to raise_error(Puppet::Error, /Parameter restart_schedule failed/)
+    end
+    it 'should reject a formatted time with a granularity of less than 60 seconds' do
+      expect do
+        config = {
+          name: 'foo',
+          restart_schedule: '00:00:45',
+        }
+        type_class.new(config)
+      end.to raise_error(Puppet::Error, /Parameter restart_schedule failed/)
+    end
   end
 
   # [


### PR DESCRIPTION
For certain parameters iis_application_pool was not idempotent. This commit fixes this by using the correct IIS names for the parameters when evaluating them for modification. It also now handles parameters that are hashes or arrays correctly.