### PR TITLE
(MODULES-5381) managed_runtime_version should allow the 'No Managed Code' value

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ iis_application_pool { 'complete_site_app_pool':
   state                   => 'Started'
 }
 
+#Application Pool No Managed Code .Net CLR Version set up
+iis_application_pool {'test_app_pool':
+    ensure                    => 'present',
+    enable32_bit_app_on_win64 => true,
+    managed_runtime_version   => '""',
+    managed_pipeline_mode     => 'Classic',
+    start_mode                => 'AlwaysRunning'
+  }
+
 iis_site { 'complete':
   ensure          => 'started',
   physicalpath    => 'c:\\inetpub\\complete',

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:iis_application_pool) do
 
   newproperty(:managed_runtime_version) do
     desc "Specifies the .NET Framework version to be used by the application pool"
-    newvalues('v1.1','v2.0','v4.0')
+    newvalues('""','v1.1','v2.0','v4.0')
   end
 
   newproperty(:pass_anonymous_token, :boolean => true) do


### PR DESCRIPTION
When setting up .Net CLR version under Application Pool settings on IIS there is no allowed value in the lib\puppet\type\iis_application_pool.rb for the value 'No Managed Code'. 
Windows translates the value "" to 'No Managed Code' on the application pool settings level.

https://tickets.puppetlabs.com/browse/MODULES-5381