### PR TITLE
(MODULES-5429) iis_site not idempotent

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     Puppet.err "Error updating website: #{result[:errormessage]}" unless result[:exitcode] == 0
     Puppet.err "Error updating website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
-    return exists?
+    return result[:exitcode] == 0
   end
 
   def destroy
@@ -62,7 +62,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     result   = self.class.run(inst_cmd)
     Puppet.err "Error destroying website: #{result[:errormessage]}" unless result[:exitcode] == 0
     Puppet.err "Error destroying website: #{result[:errormessage]}" unless result[:errormessage].nil?
-    return exists?
+    return exists? == false
   end
 
   def exists?

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     Puppet.err "Error updating website: #{result[:errormessage]}" unless result[:exitcode] == 0
     Puppet.err "Error updating website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
-    return exists?
+    return result[:exitcode] == 0
   end
 
   def destroy
@@ -64,7 +64,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     result   = self.class.run(inst_cmd)
     Puppet.err "Error destroying website: #{result[:errormessage]}" unless result[:exitcode] == 0
     Puppet.err "Error destroying website: #{result[:errormessage]}" unless result[:errormessage].nil?
-    return exists?
+    return exists? == false
   end
 
   def exists?

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -47,6 +47,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
     cmd << self.class.ps_script_content('serviceautostartprovider', @resource)
 
+
+
     inst_cmd = cmd.join
 
     result = self.class.run(inst_cmd)
@@ -75,34 +77,24 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
   def start
     create if ! exists?
-    @resource[:ensure]  = 'started'
 
-    inst_cmd = "Start-Website -Name \"#{@resource[:name]}\""
+    inst_cmd = "Start-Website -Name \"#{@resource[:name]}\" -ErrorVariable errvar;if($errvar){ throw \"$($errvar). Perhaps there is another website with this port or configuration setting\" }"
     result   = self.class.run(inst_cmd)
-    Puppet.err "Error starting website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
-    resp     = result[:stdout]
-    if resp.nil?
-      return true
-    else
-      return false
-    end
+    fail "Error starting website: #{result[:errormessage]}" unless result[:errormessage].nil? || result[:exitcode] == 0
+
+    return true
   end
 
   def stop
     create if ! exists?
-    @resource[:ensure] = 'stopped'
 
-    inst_cmd = "Stop-Website -Name \"#{@resource[:name]}\""
+    inst_cmd = "Stop-Website -Name \"#{@resource[:name]}\" -ErrorVariable errvar;if($errvar){ throw \"$($errvar).\" }"
     result   = self.class.run(inst_cmd)
-    Puppet.err "Error stopping website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
-    resp = result[:stdout]
-    if resp.nil?
-      return true
-    else
-      return false
-    end
+    fail "Error stopping website: #{result[:errormessage]}" unless result[:errormessage].nil? || result[:exitcode] == 0
+
+    return true
   end
 
   def initialize(value={})

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -17,16 +17,15 @@ Puppet::Type.newtype(:iis_site) do
       provider.start
     end
 
-    newvalue(:present) do
-      provider.create
-    end
-
     newvalue(:absent) do
       provider.destroy
     end
 
+    aliasvalue(:present, :stopped)
     aliasvalue(:false, :stopped)
     aliasvalue(:true, :started)
+    aliasvalue(:Stopped, :stopped)
+    aliasvalue(:Started, :started)
   end
 
   newparam(:name, :namevar => true) do

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -494,7 +494,7 @@ describe 'iis_site' do
       before (:all) do
         @site_name_one = "#{SecureRandom.hex(10)}"
         @site_name_two = "#{SecureRandom.hex(10)}"
-        create_site(@site_name_one, false)
+        create_site(@site_name_one, true)
         create_path('C:\inetpub\basic')
         @manifest = <<-HERE
           iis_site { '#{@site_name_two}':

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -489,5 +489,27 @@ describe 'iis_site' do
         end
       end
     end
+
+    context 'with an existing website' do
+      before (:all) do
+        @site_name_one = "#{SecureRandom.hex(10)}"
+        @site_name_two = "#{SecureRandom.hex(10)}"
+        create_site(@site_name_one, false)
+        create_path('C:\inetpub\basic')
+        @manifest = <<-HERE
+          iis_site { '#{@site_name_two}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\basic',
+            applicationpool => 'DefaultAppPool',
+          }
+        HERE
+      end
+
+      it_behaves_like 'a failing manifest'
+
+      after(:all) do
+        remove_all_sites
+      end
+    end
   end
 end


### PR DESCRIPTION
With this commit, iis_site is idempotent when ensure => 'present'.

Correct return value for update and destroy methods.

Normalize case of ensure property 'started' and 'stopped' values,
to match iis_application_pool state property 'started' and 'stopped' values.

Change ensure present present value to an aliasvalue,
as the create method is already called by the started and stopped method.