### PR TITLE
(MODULES-5443) iis name validation

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -1,6 +1,7 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
+require_relative '../../puppet_x/puppetlabs/iis/property/name'
 
 Puppet::Type.newtype(:iis_application) do
   @doc = "Manage an IIS applications."
@@ -25,11 +26,12 @@ Puppet::Type.newtype(:iis_application) do
     ]
   end
 
+  # TODO: Implement virtual path character validation, since applicationname is used in the virtual path.
   newparam(:applicationname, :namevar => true) do
     desc "The name of the Application. The virtual path of an application is /<applicationname>"
   end
 
-  newproperty(:sitename, :namevar => true) do
+  newproperty(:sitename, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of the site for this IIS Web Application'
   end
 
@@ -43,13 +45,14 @@ Puppet::Type.newtype(:iis_application) do
     end
   end
 
-  newproperty(:applicationpool) do
+  newproperty(:applicationpool, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of an ApplicationPool for this IIS Web Application'
     validate do |value|
       if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty applicationpool name must be specified."
+        raise ArgumentError, "A non-empty applicationpool must be specified."
       end
-      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
+      fail("The applicationpool must be less than 64 characters") unless value.length < 64
     end
   end
 

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/iis/property/timeformat'
@@ -22,15 +23,14 @@ Puppet::Type.newtype(:iis_application_pool) do
     defaultto :present
   end
   
-  newparam(:name, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newparam(:name, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc "The unique name of the ApplicationPool."
     validate do |value|
-      super value
       if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty #{self.name.to_s} must be specified."
+        raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{self.name.to_s} should be less than 64 characters") unless value.length < 64
-      fail("#{self.name.to_s} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
+      fail("The name must be less than 64 characters") unless value.length < 64
     end
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/name'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -29,15 +30,14 @@ Puppet::Type.newtype(:iis_site) do
     aliasvalue(:true, :started)
   end
 
-  newparam(:name, :namevar => true) do
+  newparam(:name, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc "The Name of the IIS site. Used for uniqueness. Will set
       the target to this value if target is unset."
-
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
     end
   end
 
@@ -51,13 +51,13 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:applicationpool) do
+  newproperty(:applicationpool, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of an ApplicationPool for this IIS Web Site'
     validate do |value|
       if value.nil? or value.empty?
-        raise ArgumentError, "A non-empty applicationpool name must be specified."
+        raise ArgumentError, "A non-empty applicationpool must be specified."
       end
-      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
     end
   end
 

--- a/lib/puppet_x/puppetlabs/iis/property/name.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/name.rb
@@ -1,0 +1,13 @@
+module PuppetX
+  module PuppetLabs
+    module IIS
+      module Property
+        class Name < Puppet::Property
+          validate do |value|
+            fail "#{value} is not a valid #{self.name.to_s}" unless value =~ /^[a-zA-Z0-9\.\-\_\'\s]+$/
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/iis_application_pool_spec.rb
+++ b/spec/unit/puppet/type/iis_application_pool_spec.rb
@@ -112,7 +112,6 @@ describe 'iis_application_pool' do
   ]
   
   [
-    :name,
     :clr_config_file,
     :managed_runtime_loader,
     :log_event_on_process_model,
@@ -286,4 +285,45 @@ describe 'iis_application_pool' do
   end
 
   # See https://github.com/puppetlabs/puppetlabs-azure/blob/master/spec/unit/type/azure_vm_spec.rb for more examples
+end
+
+describe Puppet::Type.type(:iis_application_pool) do
+  let(:resource) { described_class.new(:name => "test_iis_application_pool") }
+  subject { resource }
+
+  describe "parameter :name" do
+    subject { resource.parameters[:name] }
+
+    it { is_expected.to be_isnamevar }
+
+    it "should not allow nil" do
+      expect {
+        resource[:name] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for name/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:name] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty name must/)
+    end
+
+    [ 'values', 'UPPERCASEVALUES', '0123456789', 'values with spaces', "values with . - _ '" ].each do |value|
+      it "should accept '#{value}'" do
+        expect { resource[:name] = value }.not_to raise_error
+      end
+    end
+
+    [ '*', '()', '[]', '!@' ].each do |value|
+      it "should reject '#{value}'" do
+        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, /is not a valid name/)
+      end
+    end
+
+    it "should not allow values with more than 64 characters" do
+      expect {
+        resource[:name] = '01234567890123456789012345678901234567890123456789012345678901234'
+      }.to raise_error(Puppet::Error, /The name must be less than 64 characters/)
+    end
+  end
 end

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -133,3 +133,64 @@ describe 'iis_application' do
     end
   end
 end
+
+describe Puppet::Type.type(:iis_application) do
+  let(:resource) { described_class.new(:applicationname => "test_application", :sitename => 'test_site', :applicationpool => 'test_site') }
+  subject { resource }
+
+  describe "parameter :applicationname" do
+    subject { resource.parameters[:applicationname] }
+
+    it { is_expected.to be_isnamevar }
+  end
+
+  describe "parameter :sitename" do
+    subject { resource.parameters[:sitename] }
+
+    [ 'values', 'UPPERCASEVALUES', '0123456789', 'values with spaces', "values with . - _ '" ].each do |value|
+      it "should accept '#{value}'" do
+        expect { resource[:sitename] = value }.not_to raise_error
+      end
+    end
+
+    [ '*', '()', '[]', '!@' ].each do |value|
+      it "should reject '#{value}'" do
+        expect { resource[:sitename] = value }.to raise_error(Puppet::ResourceError, /is not a valid sitename/)
+      end
+    end
+  end
+
+  describe "parameter :applicationpool" do
+    subject { resource.parameters[:applicationpool] }
+
+    it "should not allow nil" do
+      expect {
+        resource[:applicationpool] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for applicationpool/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:applicationpool] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty applicationpool must/)
+    end
+
+    [ 'values', 'UPPERCASEVALUES', '0123456789', 'values with spaces', "values with . - _ '" ].each do |value|
+      it "should accept '#{value}'" do
+        expect { resource[:applicationpool] = value }.not_to raise_error
+      end
+    end
+
+    [ '*', '()', '[]', '!@' ].each do |value|
+      it "should reject '#{value}'" do
+        expect { resource[:applicationpool] = value }.to raise_error(Puppet::ResourceError, /is not a valid applicationpool/)
+      end
+    end
+
+    it "should not allow values with more than 64 characters" do
+      expect {
+        resource[:applicationpool] = '01234567890123456789012345678901234567890123456789012345678901234'
+      }.to raise_error(Puppet::Error, /The applicationpool must be less than 64 characters/)
+    end
+  end
+end

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -3,10 +3,8 @@ require 'puppet/type'
 require 'puppet/type/iis_site'
 
 describe Puppet::Type.type(:iis_site) do
-  let(:resource) { described_class.new(:name => "iis_site") }
+  let(:resource) { described_class.new(:name => "test_iis_site") }
   subject { resource }
-
-  it { is_expected.to be_a_kind_of Puppet::Type::Iis_site }
 
   describe "parameter :name" do
     subject { resource.parameters[:name] }
@@ -25,7 +23,7 @@ describe Puppet::Type.type(:iis_site) do
       }.to raise_error(Puppet::ResourceError, /A non-empty name must/)
     end
 
-    [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-' ].each do |value|
+    [ 'values', 'UPPERCASEVALUES', '0123456789', 'values with spaces', "values with . - _ '" ].each do |value|
       it "should accept '#{value}'" do
         expect { resource[:name] = value }.not_to raise_error
       end
@@ -33,7 +31,7 @@ describe Puppet::Type.type(:iis_site) do
 
     [ '*', '()', '[]', '!@' ].each do |value|
       it "should reject '#{value}'" do
-        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, /name is not a valid web site name/)
+        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, /is not a valid name/)
       end
     end
   end
@@ -104,6 +102,7 @@ describe Puppet::Type.type(:iis_site) do
       }
     end
   end
+
   context "parameter :applicationpool" do
     it "should not allow nil" do
       expect {
@@ -114,12 +113,19 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:applicationpool] = ''
-      }.to raise_error(Puppet::ResourceError, /A non-empty applicationpool name must be specified./)
+      }.to raise_error(Puppet::ResourceError, /A non-empty applicationpool must/)
     end
 
-    it "should accept any string value" do
-      resource[:applicationpool] = 'value'
-      resource[:applicationpool] = "thisstring-location"
+    [ 'values', 'UPPERCASEVALUES', '0123456789', 'values with spaces', "values with . - _ '" ].each do |value|
+      it "should accept '#{value}'" do
+        expect { resource[:applicationpool] = value }.not_to raise_error
+      end
+    end
+
+    [ '*', '()', '[]', '!@' ].each do |value|
+      it "should reject '#{value}'" do
+        expect { resource[:applicationpool] = value }.to raise_error(Puppet::ResourceError, /is not a valid applicationpool/)
+      end
     end
   end
 


### PR DESCRIPTION
With this commit, iis_site :name accepts periods, which are valid characters.
Moved the logic to a common method, as iis_site :name is used by other resources.