### PR TITLE
(MODULES-5429) Fix iis_site idempotency

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -47,6 +47,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
     cmd << self.class.ps_script_content('serviceautostartprovider', @resource)
 
+
+
     inst_cmd = cmd.join
 
     result = self.class.run(inst_cmd)
@@ -75,34 +77,24 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
   def start
     create if ! exists?
-    @resource[:ensure]  = 'started'
 
-    inst_cmd = "Start-Website -Name \"#{@resource[:name]}\""
+    inst_cmd = "Start-Website -Name \"#{@resource[:name]}\" -ErrorVariable errvar;if($errvar){ throw \"$($errvar). Perhaps there is another website with this port or configuration setting\" }"
     result   = self.class.run(inst_cmd)
-    Puppet.err "Error starting website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
-    resp     = result[:stdout]
-    if resp.nil?
-      return true
-    else
-      return false
-    end
+    fail "Error starting website: #{result[:errormessage]}" unless result[:errormessage].nil? || result[:exitcode] == 0
+
+    return true
   end
 
   def stop
     create if ! exists?
-    @resource[:ensure] = 'stopped'
 
-    inst_cmd = "Stop-Website -Name \"#{@resource[:name]}\""
+    inst_cmd = "Stop-Website -Name \"#{@resource[:name]}\" -ErrorVariable errvar;if($errvar){ throw \"$($errvar).\" }"
     result   = self.class.run(inst_cmd)
-    Puppet.err "Error stopping website: #{result[:errormessage]}" unless result[:errormessage].nil?
 
-    resp = result[:stdout]
-    if resp.nil?
-      return true
-    else
-      return false
-    end
+    fail "Error stopping website: #{result[:errormessage]}" unless result[:errormessage].nil? || result[:exitcode] == 0
+
+    return true
   end
 
   def initialize(value={})

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -494,7 +494,7 @@ describe 'iis_site' do
       before (:all) do
         @site_name_one = "#{SecureRandom.hex(10)}"
         @site_name_two = "#{SecureRandom.hex(10)}"
-        create_site(@site_name_one, false)
+        create_site(@site_name_one, true)
         create_path('C:\inetpub\basic')
         @manifest = <<-HERE
           iis_site { '#{@site_name_two}':

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -489,5 +489,27 @@ describe 'iis_site' do
         end
       end
     end
+
+    context 'with an existing website' do
+      before (:all) do
+        @site_name_one = "#{SecureRandom.hex(10)}"
+        @site_name_two = "#{SecureRandom.hex(10)}"
+        create_site(@site_name_one, false)
+        create_path('C:\inetpub\basic')
+        @manifest = <<-HERE
+          iis_site { '#{@site_name_two}':
+            ensure          => 'started',
+            physicalpath    => 'C:\\inetpub\\basic',
+            applicationpool => 'DefaultAppPool',
+          }
+        HERE
+      end
+
+      it_behaves_like 'a failing manifest'
+
+      after(:all) do
+        remove_all_sites
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit fixes the start and stop methods on the iis_site provider by
adding error catching to the IIS cmdlet invocations. It now properly fails
if Puppet is unable to start or stop a website.

Previously, when issuing a start or stop command that failed, the error
would be passed to STDOUT and not reconized as an error, so Puppet would
report the state had changed and return success. When run again, Puppet
would again miss the error and report the state has changed, causing a
never ending loop of report notifications.

Unfortunately the error returned by IIS is generic, so the reason for not
being able to start or stop the site is unknowable to Puppet during the
run. It is up to the user to figure out the conflict.