### PR TITLE
(MODULES-5465) convert version confine from fact to feature

### DIFF
--- a/lib/puppet/feature/iis_compatible_version.rb
+++ b/lib/puppet/feature/iis_compatible_version.rb
@@ -1,0 +1,46 @@
+require 'puppet/util/feature'
+
+def iis_compatible_versions
+  ['7.5', '8.0', '8.5', '10.0']
+end
+
+def iis_installed_version
+  Puppet.debug "Reading Registry for IIS Version"
+  installed_version = nil
+  begin
+    require 'win32/registry'
+    hklm        = Win32::Registry::HKEY_LOCAL_MACHINE
+    reg_path    = 'SOFTWARE\Microsoft\InetStp'
+    access_type = Win32::Registry::KEY_READ | 0x100
+    reg_key     = 'VersionString'
+    iis_version_text = ''
+    hklm.open(reg_path, access_type) do |reg|
+      iis_version_text = reg[reg_key]
+    end
+    if iis_version_text.match(/^Version (\d+\.\d+)$/)
+      installed_version = $1
+    end
+    Puppet.debug "IIS Version: #{installed_version}"
+  rescue Exception => e
+    installed_version = nil
+  end
+  installed_version
+end
+
+def iis_compatible_version_installed?
+  iis_compatible_versions.include? iis_installed_version
+end
+
+##
+
+Puppet.features.add(:iis_compatible_version) do
+  iis_compatible_version_installed?
+end
+
+# https://tickets.puppetlabs.com/browse/PUP-5985
+
+Puppet.features.send :meta_def, 'iis_compatible_version' do
+  name = :iis_compatible_version
+  @results[name] = iis_compatible_version_installed? unless @results[name]
+  @results[name]
+end

--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
+  confine    :feature         => :iis_compatible_version
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application Pool provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
+  confine    :feature         => :iis_compatible_version
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -9,7 +9,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
+  confine    :feature         => :iis_compatible_version
   confine    :operatingsystem => [:windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -4,7 +4,7 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Virtual Directory provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
+  confine    :feature         => :iis_compatible_version
   confine    :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -1,4 +1,10 @@
-$iis_version = [Double]'<%= Facter.value(:iis_version) %>'
+Try {
+  $iis_properties = Get-ItemProperty HKLM:\SOFTWARE\Microsoft\InetStp
+  $iis_version = "$($iis_properties.MajorVersion).$($iis_properties.MinorVersion)"
+}
+Catch {
+  $iis_version = ""
+}
 
 Get-WebSite | % {
   $name = $_.Name

--- a/lib/puppet/provider/templates/webadministration/logproperties.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/logproperties.ps1.erb
@@ -1,4 +1,10 @@
-$iis_version = '<%= Facter.value(:iis_version) %>'
+Try {
+  $iis_properties = Get-ItemProperty HKLM:\SOFTWARE\Microsoft\InetStp
+  $iis_version = "$($iis_properties.MajorVersion).$($iis_properties.MinorVersion)"
+}
+Catch {
+  $iis_version = ""
+}
 
 # Convert the string representation of an Enum value into an Int32 safely
 Function ConvertTo-EnumInt32 {


### PR DESCRIPTION
Prior to this commit, if IIS is installed during a run via iis_feature,
other iis_* types fail with 'Could not find a suitable provider' errors.
This is caused by confine testing a fact.

This confine tests a feature, which can (see PUP-5985) be re-evaluated,
and updates logproperties.ps1.erb to use PowerShell instead of a fact.