### PR TITLE
(MODULES-5576) Fix: iis_site Preload Enabled Not Working

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -153,6 +153,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
       site_hash[:loglocaltimerollover] = to_bool(site['loglocaltimerollover'])
       site_hash[:logformat]            = site['logformat']
       site_hash[:logflags]             = site['logextfileflags'].split(/,\s*/).sort
+      site_hash[:preloadenabled]       = to_bool(site['preloadenabled'])
 
       new(site_hash)
     end

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -22,5 +22,6 @@ Get-WebSite | %{
     logtruncatesize      = [string]$_.LogFile.truncateSize
     loglocaltimerollover = [string]$_.LogFile.localTimeRollover
     logextfileflags      = [string]$_.LogFile.logExtFileFlags
+    preloadenabled       = [string](Get-ItemProperty -Path "IIS:\Sites\$($_.Name)" -Name 'applicationDefaults.preloadEnabled' -ErrorAction 'Continue').Value
   }
 } | ConvertTo-Json -Depth 10

--- a/lib/puppet/provider/templates/webadministration/generalproperties.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/generalproperties.ps1.erb
@@ -61,7 +61,7 @@ Try-SetItemProperty @logParams
 <% if !resource[:preloadenabled].nil? -%>
 $logParams = @{
   Path  = "IIS:\Sites\$($resource.name)"
-  Name  = 'applicationDefaults.serviceAutoStartEnabled'
+  Name  = 'applicationDefaults.preloadEnabled'
   Value = '<%= "#{resource[:preloadenabled]}" %>'
 }
 Try-SetItemProperty @logParams

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -48,6 +48,7 @@ describe 'iis_site' do
               ensure               => 'started',
               applicationpool      => 'DefaultAppPool',
               enabledprotocols     => 'https',
+              preloadenabled       => true,
               bindings             => [
                 {
                   'bindinginformation'   => '*:8080:',
@@ -84,6 +85,7 @@ describe 'iis_site' do
           puppet_resource_should_show('ensure',               'started')
           puppet_resource_should_show('applicationpool',      'DefaultAppPool')
           puppet_resource_should_show('enabledprotocols',     'https')
+          puppet_resource_should_show('preloadenabled',       'true')
           #puppet_resource_should_show('bindings',             [
           #    {
           #      'bindinginformation'   => '*:8080:',


### PR DESCRIPTION
Previously, the preload enabled setting for IIS Site was setting `serviceAutostartEnabled`
instead of preload enabled. Ensure that the setting sets 'applicationDefaults.preloadEnabled'
instead.