### PR TITLE
(MODULES-5229) Add authenticationinfo to iis_site

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,24 @@ iis_site {'mysite'
 }
 ```
 
+##### `authenticationinfo`
+
+Enable and disable authentication schemas. The available schemas are: anonymous, basic, clientCertificateMapping, digest, iisClientCertificateMapping, windows.
+
+###### Example
+
+```
+iis_site { 'test_site':
+  ensure          => 'started',
+  physicalpath    => 'C:\\inetpub\\tmp',
+  applicationpool => 'DefaultAppPool',
+  authenticationinfo => {
+    'basic'     => true,
+    'anonymous' => false,
+  },
+}
+```
+
 ### iis_virtual_directory
 
 Allows creation of a new IIS Virtual Directory and configuration of virtual directory parameters.

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -7,6 +7,20 @@ Get-WebSite | % {
     $preloadenabled = [string](Get-ItemProperty -Path "IIS:\Sites\$($name)" -Name 'applicationDefaults.preloadEnabled' -ErrorAction 'Continue').Value
   }
 
+  $authenticationTypes = @(
+    'anonymous',
+    'basic',
+    'clientCertificateMapping',
+    'digest',
+    'iisClientCertificateMapping',
+    'windows'
+  )
+  $authenticationTypes | Foreach-Object -Begin { $info = @{} } -Process {
+    $p = Get-WebConfiguration -Filter "system.webserver/security/authentication/$($_)Authentication" -PSPath "IIS:\sites\$($name)"
+    $info["$($_)"] = $p.enabled
+  }
+  $authenticationinfo = New-Object -TypeName PSObject -Property $info
+
   New-Object -TypeName PSObject -Property @{
     name             = [string]$_.Name
     physicalpath     = [string]$_.PhysicalPath
@@ -29,6 +43,7 @@ Get-WebSite | % {
       maxconnections     = [int64]$_.limits.maxconnections
       connectiontimeout  = [int]$_.limits.connectiontimeout.totalseconds
     }
+    authenticationinfo   = $authenticationinfo
     logformat            = [string]$_.LogFile.logFormat
     logpath              = [string]$_.LogFile.directory
     logperiod            = [string]$_.LogFile.period

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,5 +1,6 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
+require_relative '../../puppet_x/puppetlabs/iis/property/hash'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -311,6 +312,18 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
       should.select do |k,v|
         is[k] != v
       end.empty?
+    end
+  end
+
+  newproperty(:authenticationinfo) do
+    desc 'Enable and disable authentication schemas. Note: some schemas require additional Windows features to be installed, for example windows authentication. This type does not ensure a given feature is installed before attempting to configure it.'
+    valid_schemas = ['anonymous', 'basic', 'clientCertificateMapping',
+                      'digest', 'iisClientCertificateMapping', 'windows']
+    validate do |value|
+      fail "#{self.name.to_s} should be a Hash" unless value.is_a? ::Hash
+      unless (value.keys & valid_schemas) == value.keys
+          fail("All schemas must specify any of the following: anonymous, basic, clientCertificateMapping, digest, iisClientCertificateMapping, or windows")
+      end
     end
   end
 

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -189,6 +189,32 @@ describe 'iis_site' do
       end
     end
 
+    context 'when setting' do
+      describe 'authenticationinfo' do
+        before(:all) do
+          @site_name = SecureRandom.hex(10)
+          create_path('C:\inetpub\tmp')
+          @manifest  = <<-HERE
+            iis_site { '#{@site_name}':
+              ensure          => 'started',
+              physicalpath    => 'C:\\inetpub\\tmp',
+              applicationpool => 'DefaultAppPool',
+              authenticationinfo => {
+                'basic'     => true,
+                'anonymous' => false,
+              },
+            }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        after(:all) do
+          remove_all_sites
+        end
+      end
+    end
+
     # TestRail ID: C100071
     context 'can change site state from' do
       context 'stopped to started' do

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -58,6 +58,28 @@ describe Puppet::Type.type(:iis_site) do
     end
   end
 
+  context "property: authenticationinfo" do
+    it "requires a hash or array of hashes" do
+      expect {
+        resource[:authenticationinfo] = "hi"
+      }.to raise_error(Puppet::Error, /Hash/)
+      expect {
+        resource[:authenticationinfo] = ["hi"]
+      }.to raise_error(Puppet::Error, /Hash/)
+    end
+    it "requires any of the schemas" do
+      expect {
+        resource[:authenticationinfo] = { 'wakka' => 'fdskjfndslk' }
+      }.to raise_error(Puppet::Error, /schema/)
+    end
+    it "allows valid syntax" do
+      resource[:authenticationinfo] = {
+        'basic' => true,
+        'anonymous' => false,
+      }
+    end
+  end
+
   context "property :bindings" do
     it "requires a hash or array of hashes" do
       expect {


### PR DESCRIPTION
This commit adds the ability to set authenticationinfo to iis_site by
adding a new parameter to iis_site and relevant code to the iis_site
provider. Acceptance test for code is added as well.

This commit also modifies self.prefetch to merge `provider.authenticationinfo` and `resources[site]['authenticationinfo']`. Both hashes have the correct information,  but the one that comes from the user may have a subset of all that can be specified. If we don't merge, then Puppet thinks there was a change that needs to be corrected.