### PR TITLE
(MODULES-5576) Confine IIS Version for preloadenabled

### DIFF
--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -1,4 +1,12 @@
-Get-WebSite | %{
+$iis_version = '<%= Facter.value(:iis_version) %>'
+
+Get-WebSite | % {
+  $name = $_.Name
+
+  if ($iis_version -ge '7.5') {
+    $preloadenabled = [string](Get-ItemProperty -Path "IIS:\Sites\$($name)" -Name 'applicationDefaults.preloadEnabled' -ErrorAction 'Continue').Value
+  }
+
   New-Object -TypeName PSObject -Property @{
     name             = [string]$_.Name
     physicalpath     = [string]$_.PhysicalPath
@@ -22,6 +30,6 @@ Get-WebSite | %{
     logtruncatesize      = [string]$_.LogFile.truncateSize
     loglocaltimerollover = [string]$_.LogFile.localTimeRollover
     logextfileflags      = [string]$_.LogFile.logExtFileFlags
-    preloadenabled       = [string](Get-ItemProperty -Path "IIS:\Sites\$($_.Name)" -Name 'applicationDefaults.preloadEnabled' -ErrorAction 'Continue').Value
+    preloadenabled       = $preloadenabled
   }
 } | ConvertTo-Json -Depth 10


### PR DESCRIPTION
The parameter preloadenabled is only available in IIS 8.0 or greater, so
we need to prevent the instances method from trying to get the value if
IIS 7.5 is installed.