### PR TITLE
(MODULES-5443) Fix IIS Site Name Validation

### DIFF
--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -37,7 +37,7 @@ Puppet::Type.newtype(:iis_site) do
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\.\-\_\'\s]+$/
     end
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/name'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:iis_site) do
     aliasvalue(:true, :started)
   end
 
-  newparam(:name, :namevar => true) do
+  newparam(:name, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc "The Name of the IIS site. Used for uniqueness. Will set
       the target to this value if target is unset."
 
@@ -37,7 +38,7 @@ Puppet::Type.newtype(:iis_site) do
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty name must be specified."
       end
-      fail("#{name} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\.\-\_\'\s]+$/
+      super value
     end
   end
 

--- a/lib/puppet_x/puppetlabs/iis/property/name.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/name.rb
@@ -1,0 +1,13 @@
+module PuppetX
+  module PuppetLabs
+    module IIS
+      module Property
+        class Name < Puppet::Property
+          validate do |value|
+            fail("#{value} is not a valid #{self.name.to_s}") unless value =~ /^[a-zA-Z0-9\.\-\_\'\s]+$/
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:iis_site) do
       }.to raise_error(Puppet::ResourceError, /A non-empty name must/)
     end
 
-    [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-' ].each do |value|
+    [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
       it "should accept '#{value}'" do
         expect { resource[:name] = value }.not_to raise_error
       end

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Type.type(:iis_site) do
 
     [ '*', '()', '[]', '!@' ].each do |value|
       it "should reject '#{value}'" do
-        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, /name is not a valid web site name/)
+        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, /is not a valid name/)
       end
     end
   end


### PR DESCRIPTION
This commit updates the name property of the iis_site type to allow
for the use of a period ('.') in the name. It also adjusts the spec
to verify this.