### PR TITLE
(MODULES-5521) IIS support for net.pipe protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,21 @@ iis_application { 'myapp':
 }
 ```
 
+#### `enabledprotocols`
+
+The comma-delimited list of enabled protocols for the application. Valid protocols are: 'http', 'https', 'net.pipe'.
+
+##### Example
+
+Enable http and net.pipe protocols
+```puppet
+iis_application { 'myapp':
+  ensure           => 'present',
+  sitename         => 'mysite',
+  physicalpath     => 'C:\\inetpub\\app',
+  enabledprotocols => 'http,net.pipe',
+}
+```
 
 ### iis_application_pool
 
@@ -531,7 +546,7 @@ The name of the application pool for the site.
 
 ##### `enabledprotocols`
 
-The protocols enabled for the site. If 'https' is specified, 'http' is implied. If no value is provided, then this setting is disabled.
+The protocols enabled for the site. If 'https' is specified, 'http' is implied. If no value is provided, then this setting is disabled. Can be a comma delimited list of protocols. Valid protocols are: 'http', 'https', 'net.pipe'.
 
 ##### `bindings`
 
@@ -592,6 +607,21 @@ iis_site { 'mysite':
       'certificatehash'      => '3598FAE5ADDB8BA32A061C5579829B359409856F',
       'certificatestorename' => 'MY',
       'sslflags'             => 1,
+    },
+  ],
+}
+```
+
+Binding with net.pipe protocol
+```puppet
+iis_site { 'mysite':
+  ensure               => 'started',
+  applicationpool      => 'DefaultAppPool',
+  enabledprotocols     => 'net.pipe',
+  bindings             => [
+    {
+      'bindinginformation'   => 'netpipe.website.com',
+      'protocol'             => 'net.pipe',
     },
   ],
 }

--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -31,6 +31,10 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
     end
   end
 
+  def enabledprotocols=(value)
+    @property_flush[:enabledprotocols] = value
+  end
+
   def create
     check_paths
     if @resource[:virtual_directory]
@@ -77,6 +81,10 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
       end
     end
 
+    if @property_flush[:enabledprotocols]
+      inst_cmd << "Set-WebConfigurationProperty -Filter 'system.applicationHost/sites/site[@name=\"#{resource[:sitename]}\"]/application[@path=\"/#{resource[:applicationname]}\"]' -Name enabledProtocols -Value '#{@property_flush[:enabledprotocols]}'"
+    end
+
     inst_cmd = inst_cmd.join("\n")
     result   = self.class.run(inst_cmd)
     fail "Error updating application: #{result[:errormessage]}" unless result[:exitcode] == 0
@@ -112,6 +120,7 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
       app_hash[:applicationpool]    = app['applicationpool']
       app_hash[:sslflags]           = app['sslflags']
       app_hash[:authenticationinfo] = app['authenticationinfo']
+      app_hash[:enabledprotocols]   = app['enabledprotocols']
 
       new(app_hash)
     end

--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -19,5 +19,6 @@ Get-WebApplication | % {
       iisClientCertificateMapping = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/iisClientCertificateMappingAuthentication").enabled
       windows                     = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/windowsAuthentication").enabled
     }
+    enabledprotocols = [string]$_.enabledProtocols
   }
 } | ConvertTo-Json -Depth 10

--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -76,6 +76,25 @@ Puppet::Type.newtype(:iis_application) do
     end
   end
 
+  newproperty(:enabledprotocols) do
+    desc 'Sets the enabled protocols for the application'
+    validate do |value|
+      return if value.nil?
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      
+      fail("Invalid value ''. Valid values are http, https, net.pipe") if value.empty?
+
+      protocols = value.split(',')
+      protocols.each do |protocol|
+        unless ['http', 'https', 'net.pipe'].include?(protocol)
+          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe")
+        end
+      end
+    end
+  end
+
   autorequire(:iis_application_pool) { self[:applicationpool] }
   autorequire(:iis_site) { self[:sitename] }
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -69,8 +69,14 @@ Puppet::Type.newtype(:iis_site) do
       unless value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string")
       end
-      unless ['http','https'].include?(value)
-        fail("Invalid value '#{value}'. Valid values are http, https")
+      
+      fail("Invalid value ''. Valid values are http, https, net.pipe") if value.empty?
+      
+      protocols = value.split(',')
+      protocols.each do |protocol|
+        unless ['http', 'https', 'net.pipe'].include?(protocol)
+          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe")
+        end
       end
     end
   end
@@ -95,19 +101,27 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
 
     validate do |value|
       unless value.is_a?(Hash)
-        fail("All bindings must be a hash")
+          fail("All bindings must be a hash")
       end
       unless (['protocol','bindinginformation'] - value.keys).empty?
-        fail("All bindings must specify protocol and bindinginformation values")
+          fail("All bindings must specify protocol and bindinginformation values")
       end
-      unless ["http","https"].include?(value['protocol'])
-        fail("Invalid value '#{value}'. Valid values are http, https")
+      unless ["http","https","net.pipe"].include?(value['protocol'])
+          fail("Invalid value '#{value}'. Valid values are http, https, net.pipe")
       end
-      unless value["bindinginformation"].match(%r{^.+:\d+:.*})
-        fail("bindinginformation must be of the format '(ip|*):1-65535:hostname'")
+  
+      if ["http","https"].include?(value['protocol'])
+          unless value["bindinginformation"].match(%r{^.+:\d+:.*})
+          fail("bindinginformation for http and https protocols must be of the format '(ip|*):1-65535:hostname'")
+          end
+      elsif ["net.pipe"].include?(value['protocol'])
+          unless value["bindinginformation"].match(%r{^[^:]+$})
+          fail("bindinginformation for net.pipe protocol must be of the format 'hostname'")
+          end
       end
-      if value["protocol"] == "http" and (value["sslflags"] or value["certificatehash"] or value["certificatestorename"])
-        fail("#{value["bindinginformation"]}: sslflags, certificatehash, and certificatestorename are not valid when protocol is http")
+
+      if ["http","net.pipe"].include?(value["protocol"]) and (value["sslflags"] or value["certificatehash"] or value["certificatestorename"])
+        fail("#{value["bindinginformation"]}: sslflags, certificatehash, and certificatestorename are not valid when protocol is http or net.pipe")
       end
       if value["protocol"] == "https"
         if ! [0,1,2,3].include?(value["sslflags"])

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -132,4 +132,42 @@ describe 'iis_application' do
       it { expect{subject}.to raise_error(Puppet::Error, /sslflags/) }
     end
   end
+  describe 'enabledprotocols' do
+    context 'should accept valid string value' do
+      let(:params) do
+        {
+          title: 'foo\bar',
+          enabledprotocols: 'http,https,net.pipe',
+        }
+      end
+      it { expect(subject[:enabledprotocols]).to eq('http,https,net.pipe') }
+    end
+    context 'should not allow nil' do
+      let(:params) do 
+        {
+          title: 'foo\bar',
+          enabledprotocols: nil,
+        }
+      end
+      it { expect{subject}.to raise_error(Puppet::Error, /Got nil value for enabledprotocols/) }
+    end
+    context 'should not allow empty' do
+      let(:params) do 
+        {
+          title: 'foo\bar',
+          enabledprotocols: '',
+        }
+      end
+      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe/) }
+    end
+    context 'should not accept invalid string value' do
+      let(:params) do 
+        {
+          title: 'foo\bar',
+          enabledprotocols: 'woot',
+        }
+      end
+      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe/) }
+    end
+  end
 end

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -133,19 +133,20 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:enabledprotocols] = ''
-      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https/)
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe/)
     end
 
     it "should accept valid string value" do
-      resource[:enabledprotocols] = ['http','https']
+      resource[:enabledprotocols] = ['http','https','net.pipe']
       resource[:enabledprotocols] = 'http'
       resource[:enabledprotocols] = 'https'
+      resource[:enabledprotocols] = 'net.pipe'
     end
 
     it "should not accept invalid string value" do
       expect {
         resource[:enabledprotocols] = 'woot'
-      }.to raise_error(Puppet::ResourceError, /Invalid value 'woot'. Valid values are http, https/)
+      }.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe/)
     end
   end
 


### PR DESCRIPTION
Change to allow setting of multiple enabledprotocols in both sites and web applications including http, https, and net.pipe