### PR TITLE
(MODULES-5626) IIS Application Pool Name Validation

### DIFF
--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/iis/property/timeformat'
@@ -22,15 +23,15 @@ Puppet::Type.newtype(:iis_application_pool) do
     defaultto :present
   end
   
-  newparam(:name, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newparam(:name, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc "The unique name of the ApplicationPool."
     validate do |value|
-      super value
+      fail "#{self.name.to_s} should be a String" unless value.is_a? ::String
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty #{self.name.to_s} must be specified."
       end
       fail("#{self.name.to_s} should be less than 64 characters") unless value.length < 64
-      fail("#{self.name.to_s} is not a valid web site name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
     end
   end
 

--- a/spec/unit/puppet/type/iis_application_pool_spec.rb
+++ b/spec/unit/puppet/type/iis_application_pool_spec.rb
@@ -211,6 +211,48 @@ describe 'iis_application_pool' do
 
   end
 
+  context 'parameter :name' do
+    it "should not allow nil" do
+      expect {
+        pool = type_class.new(
+          name: 'foo'
+        )
+        pool[:name] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for name/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        pool = type_class.new(
+          name: 'foo'
+        )
+        pool[:name] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty name must/)
+    end
+
+    [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
+      it "should accept '#{value}'" do
+        expect { 
+          pool = type_class.new(
+            name: 'foo'
+          )
+          pool[:name] = value
+        }.not_to raise_error
+      end
+    end
+
+    [ '*', '()', '[]', '!@' ].each do |value|
+      it "should reject '#{value}'" do
+        expect {
+          pool = type_class.new(
+            name: 'foo'
+          )
+          pool[:name] = value
+        }.to raise_error(Puppet::ResourceError, /is not a valid name/)
+      end
+    end
+  end
+
   context 'parameter :restart_schedule' do
     it 'should accept a formatted time' do
       pool = type_class.new(


### PR DESCRIPTION
This commit fixes the name validation for iis_application_pool by being
less restrictive in the regex for name, and allowing characters like
spaces and periods.