### PR TITLE
(MODULES-5627) Fix IIS application name validation

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -1,4 +1,5 @@
 require 'puppet/parameter/boolean'
+require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
 
@@ -25,11 +26,11 @@ Puppet::Type.newtype(:iis_application) do
     ]
   end
 
-  newparam(:applicationname, :namevar => true) do
+  newparam(:applicationname, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc "The name of the Application. The virtual path of an application is /<applicationname>"
   end
 
-  newproperty(:sitename, :namevar => true) do
+  newproperty(:sitename, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of the site for this IIS Web Application'
   end
 

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -68,6 +68,57 @@ describe 'iis_application' do
     end
     it { expect(subject[:physicalpath]).to eq 'C:\test' }
   end
+  
+  describe 'parameter :applicationname' do
+    [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
+      context "when '#{value}'" do
+        let(:params) do
+          {
+            title: 'foo\bar',
+            applicationname: value
+          }
+        end
+        it { expect{subject}.not_to raise_error }
+      end
+    end
+    [ '*', '()', '[]', '!@' ].each do |value|
+      context "when '#{value}'" do
+        let(:params) do
+          {
+            title: 'foo\bar',
+            applicationname: value
+          }
+        end
+        it { expect{subject}.to raise_error(Puppet::ResourceError, /is not a valid applicationname/) }
+      end
+    end
+  end
+
+  describe 'parameter :sitename' do
+    [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
+      context "when '#{value}'" do
+        let(:params) do
+          {
+            title: 'foo\bar',
+            sitename: value
+          }
+        end
+        it { expect{subject}.not_to raise_error }
+      end
+    end
+    [ '*', '()', '[]', '!@' ].each do |value|
+      context "when '#{value}'" do
+        let(:params) do
+          {
+            title: 'foo\bar',
+            sitename: value
+          }
+        end
+        it { expect{subject}.to raise_error(Puppet::ResourceError, /is not a valid sitename/) }
+      end
+    end
+  end
+
   describe 'applicationpool' do
     context 'when empty' do
       let(:params) do


### PR DESCRIPTION
This commit fixes the validation for applicationname and sitename by
being less restrictive to what is accepted, namely periods and spaces