### PR TITLE
(MODULES-5627) Fix iis_application applicationpoolname validation

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -44,13 +44,13 @@ Puppet::Type.newtype(:iis_application) do
     end
   end
 
-  newproperty(:applicationpool) do
+  newproperty(:applicationpool, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of an ApplicationPool for this IIS Web Application'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty applicationpool name must be specified."
       end
-      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
     end
   end
 

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -69,13 +69,13 @@ describe 'iis_application' do
     it { expect(subject[:physicalpath]).to eq 'C:\test' }
   end
   
-  describe 'parameter :applicationname' do
+  describe 'parameter :applicationpool' do
     [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
       context "when '#{value}'" do
         let(:params) do
           {
             title: 'foo\bar',
-            applicationname: value
+            applicationpool: value
           }
         end
         it { expect{subject}.not_to raise_error }
@@ -86,13 +86,10 @@ describe 'iis_application' do
         let(:params) do
           {
             title: 'foo\bar',
-            applicationname: value
+            applicationpool: value
           }
         end
-        it do
-          pending('Application Name validation fails under puppet resource')
-          expect{subject}.to raise_error(Puppet::ResourceError, /is not a valid applicationname/)
-        end
+        it {expect{subject}.to raise_error(Puppet::ResourceError, /is not a valid applicationpool/)}
       end
     end
   end


### PR DESCRIPTION
This commit relaxes the validation for the applicationpool parameter for
the iis_application type.