### PR TITLE
(MODULES-5954) Fix constant reassignment

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -4,14 +4,14 @@ Facter.add("iis_version") do
     iis_ver = nil
     begin
       require 'win32/registry'
-      ACCESS_TYPE = Win32::Registry::KEY_READ | 0x100
-      HKLM        = Win32::Registry::HKEY_LOCAL_MACHINE
-      REG_PATH    = 'SOFTWARE\Microsoft\InetStp'
-      REG_KEY     = 'VersionString'
+      access_type = Win32::Registry::KEY_READ | 0x100
+      hklm        = Win32::Registry::HKEY_LOCAL_MACHINE
+      reg_path    = 'SOFTWARE\Microsoft\InetStp'
+      reg_key     = 'VersionString'
       
       iis_version_text = ''
-      HKLM.open(REG_PATH, ACCESS_TYPE) do |reg|
-        iis_version_text = reg[REG_KEY]
+      hklm.open(reg_path, access_type) do |reg|
+        iis_version_text = reg[reg_key]
       end
       if iis_version_text.match(/^Version (\d+\.\d+)$/)
         iis_ver = $1


### PR DESCRIPTION
Previously facter would emit warnings that various constants in iis_version.rb
were being redefined.  This commit changes those references from constants to
variables to stop the warnings.  Also these aren't really being used as
constants (frozen strings) therefore it is safe to convert them to variables.
