### PR TITLE
(MODULES-5264) allow UNC PhysicalPath in iis_virtual_directory

### DIFF
--- a/lib/puppet/provider/iis_common.rb
+++ b/lib/puppet/provider/iis_common.rb
@@ -1,0 +1,18 @@
+def is_local_path(path)
+  return (path =~ /^.:(\/|\\)/)
+end
+
+def is_unc_path(path)
+  return (path =~ /^\\\\[^\\]+\\[^\\]+/)
+end
+
+def verify_physicalpath
+  if @resource[:physicalpath].nil? or @resource[:physicalpath].empty?
+    fail("physicalpath is a required parameter")
+  end
+  if is_local_path(@resource[:physicalpath])
+    if ! File.exists?(@resource[:physicalpath])
+      fail("physicalpath doesn't exist: #{@resource[:physicalpath]}")
+    end    
+  end
+end

--- a/lib/puppet/type/iis_virtual_directory.rb
+++ b/lib/puppet/type/iis_virtual_directory.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_virtual_directory) do
   @doc = "Manage an IIS virtual directory."
@@ -11,6 +11,11 @@ Puppet::Type.newtype(:iis_virtual_directory) do
 
   newparam(:name, :namevar => true) do
     desc 'The name of the virtual directory to manage'
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty name must be specified."
+      end
+    end
   end
 
   newproperty(:sitename) do
@@ -31,13 +36,13 @@ Puppet::Type.newtype(:iis_virtual_directory) do
     end
   end
 
-  newproperty(:physicalpath) do
-    desc 'The physical path to the IIS virtual directory folder'
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
+    desc 'The physical path to the virtual directory'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty physicalpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
+      super value
     end
   end
 

--- a/lib/puppet_x/puppetlabs/iis/property/path.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/path.rb
@@ -1,5 +1,3 @@
-# (c:\directory or c:/directory) or \\server\share
-
 module PuppetX
   module PuppetLabs
     module IIS

--- a/lib/puppet_x/puppetlabs/iis/property/path.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/path.rb
@@ -1,0 +1,17 @@
+# (c:\directory or c:/directory) or \\server\share
+
+module PuppetX
+  module PuppetLabs
+    module IIS
+      module Property
+        class Path < Puppet::Property
+          validate do |value|
+            unless value =~ /^.:(\/|\\)/ or value =~ /^\\\\[^\\]+\\[^\\]+/
+              fail("#{self.name.to_s} should be a path (local or UNC) not '#{value}'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/iis_virtual_directory_spec.rb
+++ b/spec/unit/puppet/type/iis_virtual_directory_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'iis_virtual_directory' do
+describe Puppet::Type.type(:iis_virtual_directory) do
   let(:type_class) { Puppet::Type.type(:iis_virtual_directory) }
 
   let :params do
@@ -16,21 +16,6 @@ describe 'iis_virtual_directory' do
       :application,
       :physicalpath
     ]
-  end
-
-  let :minimal_config do
-    {
-      name: 'Some Virtual Directory',
-    }
-  end
-
-  let :optional_config do
-    {
-    }
-  end
-
-  let :default_config do
-     minimal_config.merge(optional_config)
   end
 
   it 'should have expected properties' do
@@ -49,24 +34,75 @@ describe 'iis_virtual_directory' do
     expect(params + [:provider]).to include(*type_class.parameters)
   end
 
-  it 'should default ensure to present' do
-    pool = type_class.new(
-      name: 'foo',
-    )
-    expect(pool[:ensure]).to eq(:present)
+  let(:resource) { described_class.new(:name => "iis_virtual_directory") }
+  subject { resource }
+
+  describe "parameter :name" do
+    subject { resource.parameters[:name] }
+
+    it { is_expected.to be_isnamevar }
+
+    it "should not allow nil" do
+      expect {
+        resource[:name] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for name/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:name] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty name must be specified/)
+    end
   end
 
-  context 'with a minimal set of properties' do
-    let :config do
-      minimal_config
+  describe "parameter :sitename" do
+    subject { resource.parameters[:name] }
+
+    it "should not allow nil" do
+      expect {
+        resource[:sitename] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for sitename/)
     end
 
-    let :virtual_directory do
-      type_class.new(config)
+    it "should not allow empty" do
+      expect {
+        resource[:sitename] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty sitename must be specified/)
+    end
+  end
+
+  describe "parameter :application" do
+    subject { resource.parameters[:name] }
+
+    it "should not allow nil" do
+      expect {
+        resource[:application] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for application/)
     end
 
-    it 'should be valid' do
-      expect { virtual_directory }.not_to raise_error
+    it "should not allow empty" do
+      expect {
+        resource[:application] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty application must be specified/)
+    end
+  end
+
+  context "parameter :physicalpath" do
+    it "should not allow nil" do
+      expect {
+        resource[:physicalpath] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for physicalpath/)
+    end
+
+    it "should not allow empty" do
+      expect {
+        resource[:physicalpath] = ''
+      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified/)
+    end
+
+    it "should accept forward-slash and backslash paths" do
+      resource[:physicalpath] = "c:/directory/subdirectory"
+      resource[:physicalpath] = "c:\\directory\\subdirectory"
     end
   end
 end


### PR DESCRIPTION
Adds the 'Path` class to allow reuse of an accurate path validation regex  since paths are attributes of multiple types. Adds methods to test whether a path is local or remote, and if a path is local, whether the path exists.

Refactors the type to use the Path class for validation. Refactors the provider to use path methods for validation, allows the provider to create and update virtual directories with UNC paths. Adds unit tests.