### PR TITLE
(MODULES-6069) iis_site applicationpool does not allow valid characters

### DIFF
--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -52,13 +52,13 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:applicationpool) do
+  newproperty(:applicationpool, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of an ApplicationPool for this IIS Web Site'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty applicationpool name must be specified."
       end
-      fail("#{name} is not a valid applicationpool name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      super value
     end
   end
 


### PR DESCRIPTION
The fix for applicationpool was omitted from the PRs that replaced PR 100.