### PR TITLE
(MODULES-6195) Add user_name and password support to iis_virtual_directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,14 @@ The physical path to the virtual directory. This path must be fully qualified.
 
 The application under which the virtual directory is created.
 
+##### `user_name`
+
+The identity that should be impersonated when accessing the physical path. Optional.
+
+##### `password`
+
+The password associated with the `user_name` property. Optional.
+
 
 ## Limitations
 

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -32,7 +32,9 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
     end
     cmd << "-Application \"#{@resource[:application]}\" " if @resource[:application]
     cmd << "-PhysicalPath \"#{@resource[:physicalpath]}\" " if @resource[:physicalpath]
-    cmd << "-ErrorAction Stop"
+    cmd << "-ErrorAction Stop;"
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'userName' -Value '#{@resource[:user_name]}' -ErrorAction Stop;" if @resource[:user_name]
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'password' -Value '#{@resource[:password]}' -ErrorAction Stop;" if @resource[:password]
     cmd = cmd.join
 
     result   = self.class.run(cmd)
@@ -50,6 +52,8 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
     cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'site' -Value '#{@resource[:sitename]}';" if @resource[:sitename]
     cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'physicalpath' -Value '#{@resource[:physicalpath]}';" if @resource[:physicalpath]
     cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'application' -Value '#{@resource[:application]}';" if @resource[:application]
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'userName' -Value '#{@resource[:user_name]}';" if @resource[:user_name]
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'password' -Value '#{@resource[:password]}';" if @resource[:password]
 
     cmd = cmd.join
     result   = self.class.run(cmd)
@@ -105,6 +109,8 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
       virt_dir_hash[:ensure]       = :present
       virt_dir_hash[:name]         = virt_dir['name']
       virt_dir_hash[:physicalpath] = virt_dir['physicalpath']
+      virt_dir_hash[:user_name]    = virt_dir['user_name']
+      virt_dir_hash[:password]     = virt_dir['password']
       virt_dir_hash[:application]  = virt_dir['application']
       virt_dir_hash[:sitename]     = virt_dir['sitename']
 

--- a/lib/puppet/provider/templates/webadministration/_getvirtualdirectories.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getvirtualdirectories.ps1.erb
@@ -1,5 +1,7 @@
 Get-WebVirtualDirectory | ForEach-Object {
   $physicalpath = [string]$_.PhysicalPath
+  $user_name = [string]$_.userName
+  $password = [string]$_.password
   
   $name = [string]$_.Path
   $name = $name -Replace "^/", ''
@@ -20,6 +22,8 @@ Get-WebVirtualDirectory | ForEach-Object {
   New-Object -TypeName PSObject -Property @{
     name         = $name
     physicalpath = $physicalpath
+    user_name    = $user_name
+    password     = $password
     application  = $application
     sitename     = $sitename
   }

--- a/lib/puppet/type/iis_virtual_directory.rb
+++ b/lib/puppet/type/iis_virtual_directory.rb
@@ -1,5 +1,6 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/path'
+require_relative '../../puppet_x/puppetlabs/iis/property/string'
 
 Puppet::Type.newtype(:iis_virtual_directory) do
   @doc = "Manage an IIS virtual directory."
@@ -46,7 +47,22 @@ Puppet::Type.newtype(:iis_virtual_directory) do
     end
   end
 
+  newproperty(:user_name, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "Specifies the identity that should be impersonated when accessing the physical path."
+  end
+
+  newproperty(:password, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "Specifies the password associated with the user_name property."
+  end
+
   autorequire(:iis_application) { self[:application] }
   autorequire(:iis_site) { self[:sitename] }
+
+  validate do
+    unless self[:user_name].to_s.empty? && self[:password].to_s.empty?
+      raise ArgumentError, "A user_name is required when specifying password." if self[:user_name].to_s.empty?
+      raise ArgumentError, "A password is required when specifying user_name." if self[:password].to_s.empty?
+    end
+  end
 
 end

--- a/spec/unit/puppet/type/iis_virtual_directory_spec.rb
+++ b/spec/unit/puppet/type/iis_virtual_directory_spec.rb
@@ -14,7 +14,9 @@ describe Puppet::Type.type(:iis_virtual_directory) do
       :ensure,
       :sitename,
       :application,
-      :physicalpath
+      :physicalpath,
+      :user_name,
+      :password
     ]
   end
 
@@ -103,6 +105,18 @@ describe Puppet::Type.type(:iis_virtual_directory) do
     it "should accept forward-slash and backslash paths" do
       resource[:physicalpath] = "c:/directory/subdirectory"
       resource[:physicalpath] = "c:\\directory\\subdirectory"
+    end
+  end
+
+  context "parameter :user_name" do
+    it "should require it to be a string" do
+      expect(type_class).to require_string_for(:user_name)
+    end
+  end
+
+  context "parameter :password" do
+    it "should require it to be a string" do
+      expect(type_class).to require_string_for(:password)
     end
   end
 end


### PR DESCRIPTION
This commit adds user_name and password properties to iis_virtual_directory.
These are optional, and needed when IIS needs to impersonate an identity to
access the physical path.