### PR TITLE
Modules 5264 unc paths for other types

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ The name of the site for the application.
 
 The physical path to the application directory. This path must be fully qualified.
 
+##### `user_name`
+
+The identity that should be impersonated when accessing the physical path. Optional.
+
+##### `password`
+
+The password associated with the `user_name` property. Optional.
+
 #### `applicationpool`
 
 The name of the application pool for the application.
@@ -539,6 +547,14 @@ The name of the site.
 ##### `physicalpath`
 
 The physical path to the site directory. This path must be fully qualified.
+
+##### `user_name`
+
+The identity that should be impersonated when accessing the physical path. Optional.
+
+##### `password`
+
+The password associated with the `user_name` property. Optional.
 
 ##### `applicationpool`
 

--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -1,3 +1,4 @@
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_common')
 require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
@@ -40,7 +41,7 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   end
 
   def create
-    check_paths
+    verify_physicalpath if @resource[:physicalpath]
     if @resource[:virtual_directory]
       args = Array.new
       args << "#{@resource[:virtual_directory]}"
@@ -65,7 +66,7 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   end
 
   def update
-    check_paths
+    verify_physicalpath if @resource[:physicalpath]
     inst_cmd = []
 
     inst_cmd << "$webApplication = Get-WebApplication -Site '#{resource[:sitename]}' -Name '#{resource[:applicationname]}'"
@@ -132,17 +133,5 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
 
       new(app_hash)
     end
-  end
-
-  private
-
-  def check_paths
-    if @resource[:physicalpath] and ! File.exists?(@resource[:physicalpath])
-      fail "physicalpath doesn't exist: #{@resource[:physicalpath]}"
-    end
-    #XXX How do I check for IIS:\ path existence without shelling out to PS?
-    #if @resource[:virtual_directory] and ! File.exists?(@resource[:virtual_directory])
-    #  fail "virtual_directory doesn't exist: #{@resource[:virtual_directory]}"
-    #end
   end
 end

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -129,7 +129,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
 
       # In PowerShell 2.0, empty strings come in as nil which then fail insync? tests.
       # Convert nil's to empty strings for all properties which we know are String types
-      ['name','physicalpath','applicationpool','hostheader','state','serverautostart','enabledprotocols',
+      ['name','physicalpath','user_name','password','applicationpool','hostheader','state','serverautostart','enabledprotocols',
        'logformat','logpath','logperiod','logtruncatesize','loglocaltimerollover','logextfileflags'].each do |setting|
         site[setting] = '' if site[setting].nil?
       end
@@ -148,6 +148,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
       site_hash[:ensure]               = site['state'].downcase
       site_hash[:name]                 = site['name']
       site_hash[:physicalpath]         = site['physicalpath']
+      site_hash[:user_name]            = site['user_name']
+      site_hash[:password]             = site['password']
       site_hash[:applicationpool]      = site['applicationpool']
       site_hash[:serverautostart]      = to_bool(site['serverautostart'])
       site_hash[:enabledprotocols]     = site['enabledprotocols']

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -1,3 +1,4 @@
+require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_common')
 require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershell')
 
 # When writing IIS PowerShell code for any of the methods below
@@ -18,6 +19,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
   mk_resource_methods
 
   def create
+    verify_physicalpath
+
     cmd = []
 
     cmd << self.class.ps_script_content('_newwebsite', @resource)
@@ -33,6 +36,8 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
   end
 
   def update
+    verify_physicalpath
+
     cmd = []
 
     cmd << self.class.ps_script_content('_setwebsite', @resource)

--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -10,6 +10,8 @@ Get-WebSite | % {
   New-Object -TypeName PSObject -Property @{
     name             = [string]$_.Name
     physicalpath     = [string]$_.PhysicalPath
+    user_name        = [string]$_.userName
+    password         = [string]$_.password
     applicationpool  = [string]$_.ApplicationPool
     hostheader       = [string]$_.HostHeader
     state            = [string]$_.State

--- a/lib/puppet/provider/templates/webadministration/generalproperties.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/generalproperties.ps1.erb
@@ -16,6 +16,24 @@ $pathParams = @{
 Try-SetItemProperty @pathParams
 <% end -%>
 
+<% if !resource[:user_name].nil? -%>
+$usernameParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'userName'
+  Value = '<%= "#{resource[:user_name]}" %>'
+}
+Try-SetItemProperty @usernameParams
+<% end -%>
+
+<% if !resource[:password].nil? -%>
+$passwordParams = @{
+  Path  = "IIS:\Sites\$($resource.name)"
+  Name  = 'password'
+  Value = '<%= "#{resource[:password]}" %>'
+}
+Try-SetItemProperty @passwordParams
+<% end -%>
+
 <% if !resource[:applicationpool].nil? -%>
 $poolParams = @{
   Path  = "IIS:\Sites\$($resource.name)"

--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -1,23 +1,47 @@
 Get-WebApplication | % {
   $name = [string]$_.Path.replace("/","")
   $site = [string]$_.ItemXPath.split("'")[1]
+  $id   = [string]$_.ItemXPath.split("'")[3]
+
+  $user_name = [String](Get-WebConfigurationProperty -Filter "/system.applicationHost/sites/site[@name='${site}' and @id='${id}']/application[@path='/${name}']/virtualDirectory[@path='/']" -Name userName).Value
+  $password  = [String](Get-WebConfigurationProperty -Filter "/system.applicationHost/sites/site[@name='${site}' and @id='${id}']/application[@path='/${name}']/virtualDirectory[@path='/']" -Name password).Value
 
   $sslFlags = @()
-  $sslFlags_raw = [String](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/access").sslFlags
-  if ($sslFlags_raw -ne '') { $sslFlags = $sslFlags_raw -split ',' }
+  $auth_anonymous                   = 'unknown'
+  $auth_basic                       = 'unknown'
+  $auth_clientCertificateMapping    = 'unknown'
+  $auth_iisClientCertificateMapping = 'unknown'
+  $auth_windows                     = 'unknown'
+  $provider_error                   = ''
+
+  # 'Get-WebConfiguration -Location' can fail if the identity cannot access physicalpath.
+  try {
+    $sslFlags_raw                     = [String](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/access").sslFlags
+    if ($sslFlags_raw -ne '') { $sslFlags = $sslFlags_raw -split ',' }
+    $auth_anonymous                   = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/anonymousAuthentication").enabled
+    $auth_basic                       = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/basicAuthentication").enabled
+    $auth_clientCertificateMapping    = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/clientCertificateMappingAuthentication").enabled
+    $auth_iisClientCertificateMapping = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/iisClientCertificateMappingAuthentication").enabled
+    $auth_windows                     = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/windowsAuthentication").enabled
+  }catch{
+    $provider_error = 'Get-WebConfiguration error. Please review the identity accessing physicalpath.'
+  }
 
   New-Object -TypeName PSObject -Property @{
+    _provider_error    = $provider_error
     name               = $name
     site               = $site
     applicationpool    = [string]$_.ApplicationPool
     physicalpath       = [string]$_.PhysicalPath
+    user_name          = $user_name
+    password           = $password
     sslflags           = $sslFlags
     authenticationinfo = New-Object -TypeName PSObject -Property @{
-      anonymous                   = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/anonymousAuthentication").enabled
-      basic                       = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/basicAuthentication").enabled
-      clientCertificateMapping    = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/clientCertificateMappingAuthentication").enabled
-      iisClientCertificateMapping = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/iisClientCertificateMappingAuthentication").enabled
-      windows                     = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/windowsAuthentication").enabled
+      anonymous                   = $auth_anonymous
+      basic                       = $auth_basic
+      clientCertificateMapping    = $auth_clientCertificateMapping
+      iisClientCertificateMapping = $auth_iisClientCertificateMapping
+      windows                     = $auth_windows
     }
     enabledprotocols = [string]$_.enabledProtocols
   }

--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -45,6 +45,14 @@ Puppet::Type.newtype(:iis_application) do
     end
   end
 
+  newproperty(:user_name, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "Specifies the identity that should be impersonated when accessing the physical path."
+  end
+
+  newproperty(:password, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "Specifies the password associated with the user_name property."
+  end
+
   newproperty(:applicationpool, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
     desc 'The name of an ApplicationPool for this IIS Web Application'
     validate do |value|
@@ -102,5 +110,10 @@ Puppet::Type.newtype(:iis_application) do
 
   validate do
     fail("sitename is a required parameter") if (provider && ! provider.sitename) or ! self[:sitename]
+
+    unless self[:user_name].to_s.empty? && self[:password].to_s.empty?
+      raise ArgumentError, "A user_name is required when specifying password." if self[:user_name].to_s.empty?
+      raise ArgumentError, "A password is required when specifying user_name." if self[:password].to_s.empty?
+    end
   end
 end

--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -1,5 +1,6 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
 
@@ -34,13 +35,13 @@ Puppet::Type.newtype(:iis_application) do
     desc 'The name of the site for this IIS Web Application'
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the IIS web application folder'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty physicalpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
+      super value
     end
   end
 

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -1,6 +1,7 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 require_relative '../../puppet_x/puppetlabs/iis/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/iis/property/timeformat'
 
@@ -52,7 +53,7 @@ Puppet::Type.newtype(:iis_application_pool) do
     end
   end
 
-  newproperty(:clr_config_file, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newproperty(:clr_config_file, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc "Specifies the .NET configuration file for the application pool"
   end
 

--- a/lib/puppet/type/iis_feature.rb
+++ b/lib/puppet/type/iis_feature.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require_relative '../../puppet_x/puppetlabs/iis/property/string'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_feature) do
   @doc = "Manage an IIS installed features."
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:iis_feature) do
     desc "Indicates whether to automatically install all managment tools for a given IIS feature"
   end
 
-  newparam(:source, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+  newparam(:source, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc "Optionally include a source path for the installation media for an IIS feature"
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,5 +1,6 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -42,13 +43,13 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the IIS web site folder'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty physicalpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
+      super value
     end
   end
 
@@ -220,13 +221,13 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
     end
   end
 
-  newproperty(:logpath) do
+  newproperty(:logpath, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
     desc 'Specifies the physical path to place the log file'
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty logpath must be specified."
       end
-      fail("File paths must be fully qualified, not '#{value}'") unless value =~ /^.:(\/|\\)/ or value =~ /^\/\/[^\/]+\/[^\/]+/
+      super value
     end
   end
 

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,6 +1,7 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/path'
+require_relative '../../puppet_x/puppetlabs/iis/property/string'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Create a new IIS website."
@@ -51,6 +52,14 @@ Puppet::Type.newtype(:iis_site) do
       end
       super value
     end
+  end
+
+  newproperty(:user_name, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "Specifies the identity that should be impersonated when accessing the physical path."
+  end
+
+  newproperty(:password, :parent => PuppetX::PuppetLabs::IIS::Property::String) do
+    desc "Specifies the password associated with the user_name property."
   end
 
   newproperty(:applicationpool, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do
@@ -322,6 +331,11 @@ The sslflags parameter accepts integer values from 0 to 3 inclusive.
     
     if self[:serviceautostartprovidertype]
       fail("Must specify serviceautostartprovidername as well as serviceautostartprovidertype") unless self[:serviceautostartprovidername]
+    end
+
+    unless self[:user_name].to_s.empty? && self[:password].to_s.empty?
+      raise ArgumentError, "A user_name is required when specifying password." if self[:user_name].to_s.empty?
+      raise ArgumentError, "A password is required when specifying user_name." if self[:password].to_s.empty?
     end
 
     provider.validate if provider.respond_to?(:validate)

--- a/lib/puppet_x/puppetlabs/iis/property/path.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/path.rb
@@ -5,7 +5,7 @@ module PuppetX
         class Path < Puppet::Property
           validate do |value|
             unless value =~ /^.:(\/|\\)/ or value =~ /^\\\\[^\\]+\\[^\\]+/
-              fail("#{self.name.to_s} should be a path (local or UNC) not '#{value}'")
+              fail("#{self.name.to_s} should be a Path (local or UNC) not '#{value}'")
             end
           end
         end

--- a/spec/support/matchers/type_provider_interface.rb
+++ b/spec/support/matchers/type_provider_interface.rb
@@ -1,3 +1,15 @@
+RSpec::Matchers.define :require_path_for do |property|
+  match do |type_class|
+    config = {name: 'name'}
+    config[property] = 2
+    expect do
+      type_class.new(config)
+    end.to raise_error(Puppet::Error, /#{property} should be a Path/)
+  end
+  failure_message do |type_class|
+    "#{type_class} should require #{property} to be a Path"
+  end
+end
 
 RSpec::Matchers.define :require_string_for do |property|
   match do |type_class|

--- a/spec/unit/puppet/type/iis_application_pool_spec.rb
+++ b/spec/unit/puppet/type/iis_application_pool_spec.rb
@@ -113,7 +113,6 @@ describe 'iis_application_pool' do
   
   [
     :name,
-    :clr_config_file,
     :managed_runtime_loader,
     :log_event_on_process_model,
     :orphan_action_exe,
@@ -125,6 +124,14 @@ describe 'iis_application_pool' do
   ].each do |property|
     it "should require #{property} to be a string" do
       expect(type_class).to require_string_for(property)
+    end
+  end
+
+  [
+    :clr_config_file,
+  ].each do |property|
+    it "should require #{property} to be a path" do
+      expect(type_class).to require_path_for(property)
     end
   end
 

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -38,7 +38,6 @@ describe Puppet::Type.type(:iis_site) do
     end
   end
 
-  # TODO: fix tests below
   context "parameter :physicalpath" do
     it "should not allow nil" do
       expect {
@@ -49,12 +48,12 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:physicalpath] = ''
-      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified./)
+      }.to raise_error(Puppet::Error, /A non-empty physicalpath must be specified/)
     end
 
-    it "should accept any string value" do
-      resource[:physicalpath] = "c:/thisstring-location/value/somefile.txt"
-      resource[:physicalpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    it "should accept forward-slash and backslash paths" do
+      resource[:physicalpath] = "c:/directory/subdirectory"
+      resource[:physicalpath] = "c:\\directory\\subdirectory"
     end
   end
 
@@ -312,12 +311,12 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:logpath] = ''
-      }.to raise_error(Puppet::Error, /A non-empty logpath must be specified./)
+      }.to raise_error(Puppet::Error, /A non-empty logpath must be specified/)
     end
 
-    it "should accept any string value" do
-      resource[:logpath] = "c:/thisstring-location/value/somefile.txt"
-      resource[:logpath] = "c:\\thisstring-location\\value\\somefile.txt"
+    it "should accept forward-slash and backslash paths" do
+      resource[:logpath] = "c:/directory/subdirectory"
+      resource[:logpath] = "c:\\directory\\subdirectory"
     end
   end
 


### PR DESCRIPTION
This commit refactors other types to allow UNC paths where allowed.

This commit adds user_name and password properties to iis application and site.
These are optional, and needed when IIS needs to impersonate an identity to
access the physical path.