### PR TITLE
(MODULES-6062) Fix iis_virtual_directory idempotency

### DIFF
--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -60,10 +60,10 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
     Puppet.debug "Destroying #{@resource[:name]}"
     cmd = []
     cmd << "Remove-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
-    cmd << "-Site \"#{@resource[:sitename]}\" " if @resource[:sitename]
+    cmd << "-Site \"#{@property_hash[:sitename]}\" "
     
-    if @resource[:application]
-      cmd << "-Application \"#{@resource[:application]}\" "
+    if @property_hash[:application]
+      cmd << "-Application \"#{@property_hash[:application]}\" "
     else
       cmd << "-Application \"/\" "
     end
@@ -74,7 +74,7 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
     result   = self.class.run(cmd)
     Puppet.err "Error destroying virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
     
-    @resource[:ensure]  = :absent
+    @property_hash[:ensure] = :absent
   end
 
   def initialize(value={})

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -43,6 +43,33 @@ describe 'iis_virtual_directory' do
         remove_vdir(@virt_dir_name)
       end
     end
+
+    context 'can remove virtual directory' do
+      before(:all) do
+        @virt_dir_name = "#{SecureRandom.hex(10)}"
+        create_path('c:/foo')
+        create_vdir(@virt_dir_name, 'foo', 'c:/foo')
+        @manifest  = <<-HERE
+          iis_virtual_directory { '#{@virt_dir_name}':
+            ensure       => 'absent'
+          }
+        HERE
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      context 'when puppet resource is run' do
+        before(:all) do
+          @result = resource('iis_virtual_directory', @virt_dir_name)
+        end
+
+        puppet_resource_should_show('ensure', 'absent')
+      end
+
+      after(:all) do
+        remove_vdir(@virt_dir_name)
+      end
+    end
     
     context 'name allows slashes' do
       context 'simple case' do

--- a/spec/support/utilities/iis_virtual_directory.rb
+++ b/spec/support/utilities/iis_virtual_directory.rb
@@ -3,13 +3,13 @@ def has_vdir(vdir_name)
   !(on(default, command).stdout =~ /Name/i).nil?
 end
 
-def create_vdir(vdir_name)
-  command = format_powershell_iis_command("New-WebVirtualDirectory -Name #{@vdir_name}")
+def create_vdir(vdir_name, site = 'foo', path = 'C:\inetpub\wwwroot')
+  command = format_powershell_iis_command("New-WebVirtualDirectory -Name #{@vdir_name} -Site #{@site} -PhysicalPath #{@path}")
   on(default, command) unless has_vdir(vdir_name)
 end
 
-def remove_vdir(vdir_name)
-  command = format_powershell_iis_command("Remove-WebVirtualDirectory -Name #{vdir_name}")
+def remove_vdir(vdir_name, site = 'foo', path = 'C:\inetpub\wwwroot')
+  command = format_powershell_iis_command("Remove-WebVirtualDirectory -Name #{vdir_name} -Site #{@site} -PhysicalPath #{@path}")
   on(default, command) if has_vdir(vdir_name)
 end
 


### PR DESCRIPTION
This commit fixes the iis_virtual_directory destroy method to provide
the required paramters to the Remove-WebVirtualDirectory command so that
it successfully removes a virtual directory.

It also uses `@property_hash` instead of `@resource` inside the destroy
method, so that the flush method works properly after removing a virtual
directory.

Lastly, it updates the spec acceptance test to properly create and
destroy virtual directories instead of failing silently.
