### PR TITLE
(maint) Remove iis_virtual_directory destroy check

### DIFF
--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -61,19 +61,13 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
     cmd = []
     cmd << "Remove-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
     cmd << "-Site \"#{@property_hash[:sitename]}\" "
-    
-    if @property_hash[:application]
-      cmd << "-Application \"#{@property_hash[:application]}\" "
-    else
-      cmd << "-Application \"/\" "
-    end
-    
+    cmd << "-Application \"#{@property_hash[:application]}\" "
     cmd << "-ErrorAction Stop"
     cmd = cmd.join
 
     result   = self.class.run(cmd)
     Puppet.err "Error destroying virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
-    
+
     @property_hash[:ensure] = :absent
   end
 
@@ -111,5 +105,5 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
       new(virt_dir_hash)
     end
   end
-  
+
 end


### PR DESCRIPTION
 - The PowerShell helper at _getvirtualdirectories.ps1.erb always
   returns an application of '/' when one is not specified.

   When the .instances method enumerates existing virtual directories
   it creates new provider instances, filling @property_hash with
   the values returned from the PowerShell helper.

   Therefore @property_hash[:application] should never be nil and the
   check here is not necessary.