### PR TITLE
(MODULES-6166) virtual_directory requires sitename

### DIFF
--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -24,7 +24,8 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
     cmd = []
     if is_local_path(@resource[:physicalpath])
       cmd << "New-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
-      cmd << "-Site \"#{@resource[:sitename]}\" " if @resource[:sitename]
+      fail("sitename is a required parameter") unless @resource[:sitename]
+      cmd << "-Site \"#{@resource[:sitename]}\" "
     else
       # New-WebVirtualDirectory fails when PhysicalPath is a UNC path that unavailable,
       # and UNC paths are inherently not necessarily always available.


### PR DESCRIPTION
 - Previously `puppet resource iis_virtualdirectory ensure=present`
   would report success even though it failed, when `sitename` was
   left unspecified:

```
bundle exec puppet resource iis_virtual_directory foo physicalpath=c:/foo ensure=present --modulepath .\spec\fixtures\modules\
Notice: /Iis_virtual_directory[foo]/ensure: created
iis_virtual_directory { 'foo':
  ensure => 'absent',
}
```

Asking for a list of iis_virtual_directory would yield no results

```
bundle exec puppet resource iis_virtual_directory --modulepath .\spec\fixtures\modules\
```

 - This change introduces a hard failure when sitename is not specified

```
bundle exec puppet resource iis_virtual_directory foo physicalpath=c:/foo ensure=present --modulepath .\spec\fixtures\modules\
Error: sitename is a required parameter
Error: /Iis_virtual_directory[foo]/ensure: change from 'absent' to 'present' failed: sitename is a required parameter
iis_virtual_directory { 'foo':
  ensure => 'absent',
}
```