### PR TITLE
(maint) MODULES-5561 skip test

### DIFF
--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -85,6 +85,7 @@ describe 'iis_application' do
   # TestRail ID: C100062
   context 'when setting' do
     describe 'sslflags' do
+      skip("blocked by MODULES-5561")
       before(:all) do
         @site_name = SecureRandom.hex(10)
         @app_name = SecureRandom.hex(10)


### PR DESCRIPTION
Skip an acceptance test for idempotency. The test fails for a known reason with a ticket to fix.