### PR TITLE
(maint) MODULES-5561 Skip a test that failes for a known reason.

### DIFF
--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -84,8 +84,7 @@ describe 'iis_application' do
 
   # TestRail ID: C100062
   context 'when setting' do
-    describe 'sslflags' do
-      skip("blocked by MODULES-5561")
+    skip 'sslflags - blocked by MODULES-5561' do
       before(:all) do
         @site_name = SecureRandom.hex(10)
         @app_name = SecureRandom.hex(10)


### PR DESCRIPTION
This skip syntax works on Windows 2008r2, whereas the previous skip() function did not.

This was not caught in previous testing because the skip() change was only tested on a single Windows platform. Jenkins tested on all supported platforms and caught the fact that this doesn't work on 2008r2.