### PR TITLE
(WIP) MODULES-6381 Create site with alternate port

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -168,4 +168,18 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     return :false  if value == false  || value =~ (/(^$|false|f|no|n|0)$/i)
     raise ArgumentError.new("invalid value for Boolean: \"#{value}\"")
   end
+
+  def binding_value
+
+    if @resource[:bindings] != nil
+      binding = @resource[:bindings].select {|binding| binding.to_s !~ /\*:80:/ }.first
+      int_binding = binding != nil ? binding['bindinginformation'].match(/:([0-9]*):/).captures.first : nil
+    end
+
+    if int_binding != nil
+      return int_binding
+    else 
+      return nil
+    end
+  end
 end

--- a/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
@@ -11,6 +11,8 @@ $createParams = @{
   ApplicationPool = $resource.applicationpool
   Force           = $true
   ErrorAction     = 'Stop'
+  <%= resource.provider.binding_value ? "port            = #{resource.provider.binding_value}" : nil %>
+  <%= resource.provider.binding_value == '443' ? "Ssl           = $true" : nil %>
 }
 
 # If there are no other websites, specify the Id, otherwise an Index Out of Range error can be thrown


### PR DESCRIPTION
If a user puts a non 443 and non 80 port in the binding information
this change will use the supplied port from the binding information hash
to create the website.