### PR TITLE
(MODULES-6385) Create site with alternate port

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -168,4 +168,11 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     return :false  if value == false  || value =~ (/(^$|false|f|no|n|0)$/i)
     raise ArgumentError.new("invalid value for Boolean: \"#{value}\"")
   end
+
+  def binding_port
+    if @resource[:bindings]
+      binding = @resource[:bindings].first
+      return binding['bindinginformation'].match(/:([0-9]*):/).captures.first
+    end
+  end
 end

--- a/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
@@ -11,6 +11,7 @@ $createParams = @{
   ApplicationPool = $resource.applicationpool
   Force           = $true
   ErrorAction     = 'Stop'
+<%= "port            = #{resource.provider.binding_port}" unless resource.provider.binding_port.nil? %>
 }
 
 # If there are no other websites, specify the Id, otherwise an Index Out of Range error can be thrown


### PR DESCRIPTION
This change will ensure that a user can avoid collisions on port 80 when
creating a new website. Prior to this change when the module created a new 
website, it was not able to see the port binding information when it called the
New-Website cmdlet. This meant that if a website already existed with a binding
to port 80, the site would fail to start. Since New-Website always attempts to
start the website after it is created, this would cause the whole manifest to
fail. With this change, if a binding other than port 80 is specified, that
binding is used in the call to New-Website, and the conflict is avoided.