### PR TITLE
(MODULES-5465) add puppet feature suitability

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,24 +1,7 @@
 Facter.add("iis_version") do
  confine :kernel => :windows
   setcode do
-    iis_ver = nil
-    begin
-      require 'win32/registry'
-      access_type = Win32::Registry::KEY_READ | 0x100
-      hklm        = Win32::Registry::HKEY_LOCAL_MACHINE
-      reg_path    = 'SOFTWARE\Microsoft\InetStp'
-      reg_key     = 'VersionString'
-      
-      iis_version_text = ''
-      hklm.open(reg_path, access_type) do |reg|
-        iis_version_text = reg[reg_key]
-      end
-      if iis_version_text.match(/^Version (\d+\.\d+)$/)
-        iis_ver = $1
-      end
-    rescue
-      iis_ver = nil
-    end
-    iis_ver
+    require_relative '../puppet_x/puppetlabs/iis/iis_version'
+    PuppetX::PuppetLabs::IIS::IISVersion::installed_version
   end
 end

--- a/lib/puppet/feature/iis_web_server.rb
+++ b/lib/puppet/feature/iis_web_server.rb
@@ -1,0 +1,12 @@
+require 'puppet/util/feature'
+require_relative '../../../lib/puppet_x/puppetlabs/iis/iis_version'
+
+Puppet.features.add(:iis_web_server) do
+  PuppetX::PuppetLabs::IIS::IISVersion.supported_version_installed?
+end
+
+Puppet.features.send :meta_def, 'iis_web_server?' do
+  name = :iis_web_server
+  @results[name] = PuppetX::PuppetLabs::IIS::IISVersion.supported_version_installed? unless @results[name]
+  @results[name]
+end

--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -3,8 +3,8 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
-  confine    :operatingsystem => [ :windows ]
+  confine     :feature         => :iis_web_server
+  confine     :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 
   commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -3,8 +3,8 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Application Pool provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
-  confine    :operatingsystem => [ :windows ]
+  confine     :feature         => :iis_web_server
+  confine     :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 
   commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -9,8 +9,8 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
-  confine    :operatingsystem => [:windows ]
+  confine     :feature         => :iis_web_server
+  confine     :operatingsystem => [:windows ]
   defaultfor :operatingsystem => :windows
 
   commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -4,8 +4,8 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc "IIS Virtual Directory provider using the PowerShell WebAdministration module"
 
-  confine    :iis_version     => ['7.5', '8.0', '8.5', '10.0']
-  confine    :operatingsystem => [ :windows ]
+  confine     :feature         => :iis_web_server
+  confine     :operatingsystem => [ :windows ]
   defaultfor :operatingsystem => :windows
 
   commands :powershell => PuppetX::IIS::PowerShellCommon.powershell_path

--- a/lib/puppet_x/puppetlabs/iis/iis_version.rb
+++ b/lib/puppet_x/puppetlabs/iis/iis_version.rb
@@ -1,0 +1,56 @@
+module PuppetX
+  module PuppetLabs
+    module IIS
+      class IISVersion
+        def self.supported_version_installed?
+          false
+        end
+      end
+    end
+  end
+end
+
+if Puppet::Util::Platform.windows?
+  require 'win32/registry'
+  module PuppetX
+    module PuppetLabs
+      module IIS
+        class IISVersion
+
+          def self.supported_versions
+            ['7.5', '8.0', '8.5','10.0']
+          end
+
+          def self.installed_version
+            version = nil
+            begin
+
+              hklm        = Win32::Registry::HKEY_LOCAL_MACHINE
+              reg_path    = 'SOFTWARE\Microsoft\InetStp'
+              access_type = Win32::Registry::KEY_READ | 0x100
+
+              major_version = ''
+              minor_version = ''
+
+              hklm.open(reg_path, access_type) do |reg|
+                major_version = reg['MajorVersion']
+                minor_version = reg['MinorVersion']
+              end
+
+              version = "#{major_version}.#{minor_version}"
+
+            rescue Exception => e
+              version = nil
+            end
+            version
+          end
+
+          def self.supported_version_installed?
+            supported_versions.include? installed_version
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet_x/puppetlabs/iis/iis_version_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/iis/iis_version_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet_x/puppetlabs/iis/iis_version'
+
+describe PuppetX::PuppetLabs::IIS::IISVersion, :if => Puppet::Util::Platform.windows? do
+  before(:each) do
+    @ps = PuppetX::PuppetLabs::IIS::IISVersion
+  end
+
+  describe "when iis is installed" do
+
+    it "should detect a iis version" do
+      Win32::Registry.any_instance.expects(:[])
+        .with('MajorVersion').returns('10')
+      Win32::Registry.any_instance.expects(:[])
+        .with('MinorVersion').returns('0')
+
+      version = @ps.installed_version
+
+      expect(version).not_to be_nil
+    end
+
+    it "should report true if iis supported version installed" do
+      Win32::Registry.any_instance.expects(:[])
+        .with('MajorVersion').returns('10')
+      Win32::Registry.any_instance.expects(:[])
+        .with('MinorVersion').returns('0')
+
+      result = @ps.supported_version_installed?
+
+      expect(result).to be_truthy
+    end
+
+    it "should report false if no iis supported version installed" do
+      Win32::Registry.any_instance.expects(:[])
+        .with('MajorVersion').returns('6')
+      Win32::Registry.any_instance.expects(:[])
+        .with('MinorVersion').returns('0')
+
+      result = @ps.supported_version_installed?
+
+      expect(result).to be_falsey
+    end
+
+  end
+
+  describe "when iis is not installed" do
+
+    it "should return nil and not throw" do
+      Win32::Registry.any_instance
+        .expects(:open)
+        .with('SOFTWARE\Microsoft\InetStp', Win32::Registry::KEY_READ | 0x100)
+        .raises(Win32::Registry::Error.new(2), 'nope')
+        .once
+
+      version = @ps.installed_version
+
+      expect(version).to eq nil
+    end
+
+  end
+end


### PR DESCRIPTION
(MODULES-5465) Add puppet feature suitability

This commit changes the confine for all providers to use a puppet
feature instead of a puppet fact. This allows the provider to install
IIS and then use one of the providers to configure it in the same Puppet
run. A feature is used instead of a fact because a feature can be
re-evaluated during the Puppet run and a fact cannot.

This commit also extracts the IIS detection logic out to a class in
order to isolate the parts that decide what IIS versions we support and
how to determine existance of IIS on the target node. Appropriate spec
tests are added for the class.

Automated acceptance tests were not added for this, as the
spec_helper_acceptance installs IIS before any tests are run. Since this
change is to enable installing and configuring IIS in the same run, we
would have to re-write all of the tests in order to be able to add one
test for this. This has been manually validated instead.