### PR TITLE
(MODULES-6257) Fix Applications in Nested Subfolders

### DIFF
--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -1,5 +1,7 @@
+[regex]$pattern = '/'
+
 Get-WebApplication | % {
-  $name = [string]$_.Path.replace("/","")
+  $name = [string]$pattern.replace($_.Path,'',1)
   $site = [string]$_.ItemXPath.split("'")[1]
 
   $sslFlags = @()

--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -28,6 +28,11 @@ Puppet::Type.newtype(:iis_application) do
 
   newparam(:applicationname, :namevar => true) do
     desc "The name of the Application. The virtual path of an application is /<applicationname>"
+    validate do |value|
+      if value =~ /^\/|^\\/
+        raise ArgumentError, "cannot begin applicationname property with a '\\' or a '/' character"
+      end
+    end
   end
 
   newproperty(:sitename, :namevar => true, :parent => PuppetX::PuppetLabs::IIS::Property::Name) do


### PR DESCRIPTION
(MODULES-6257) This commit allows the user to create and manage IIS
Applications in nested subfolders. Prior to this change an application
in a nested subfolder had its name handled improperly, such that the
iis_application resource was unable to detect that the application
specified in the manifest already existed.