### PR TITLE
(MODULES-6673) Ensure Present IIS Site Loop

### DIFF
--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -20,11 +20,17 @@ Puppet::Type.newtype(:iis_site) do
     end
 
     newvalue(:present) do
-      provider.create
+      provider.create unless provider.exists?
     end
 
     newvalue(:absent) do
       provider.destroy
+    end
+
+    def insync?(is)
+      is.to_s == should.to_s or
+        (is.to_s == 'started' and should.to_s == 'present') or
+        (is.to_s == 'stopped' and should.to_s == 'present')
     end
 
     aliasvalue(:false, :stopped)

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -617,6 +617,47 @@ describe 'iis_site' do
         remove_all_sites
       end
     end
+
+    context 'with ensure set to present' do
+      before(:all) do
+        create_path('C:\inetpub\basic')
+        @site_name = "#{SecureRandom.hex(10)}"
+        create_site(@site_name, true)
+
+        setup_manifest = <<-HERE
+        iis_site { '#{@site_name}':
+            ensure           => 'stopped',
+            physicalpath     => 'C:\\inetpub\\basic',
+            applicationpool  => 'DefaultAppPool',
+            logformat        => 'W3C',
+            logflags         => ['ClientIP', 'Date', 'HttpStatus']
+        }
+        HERE
+
+        @manifest = <<-HERE
+        iis_site { '#{@site_name}':
+            ensure           => 'present',
+            physicalpath     => 'C:\\inetpub\\basic',
+            applicationpool  => 'DefaultAppPool',
+            logformat        => 'W3C',
+            logflags         => ['ClientIP', 'Date', 'HttpStatus']
+        }
+        HERE
+
+        execute_manifest(setup_manifest, :catch_failures => true)
+
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      context 'when puppet resource is run' do
+        before(:all) do
+          @result = resource('iis_site', @site_name)
+        end
+
+        puppet_resource_should_show('ensure', 'stopped')
+      end
+    end
   end
 
   context 'with conflicting sites on port 80 but different host headers' do


### PR DESCRIPTION
This change ensures that if a user sets the Ensure property of a
manifest to present that Puppet run will neither attempt to start the
site if it is stopped nor display a state transition message to the
terminal and the logs specifying a change from <state> to present.