### PR TITLE
(MODULES-6637) Port Conflict Hostname Only

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -184,10 +184,11 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
     raise ArgumentError.new("invalid value for Boolean: \"#{value}\"")
   end
 
-  def binding_port
-    if @resource[:bindings]
+  def binding_information
+    if @resource[:bindings] && (["http","https"].include?(@resource['bindings'].first['protocol']))
       binding = @resource[:bindings].first
-      return binding['bindinginformation'].match(/:([0-9]*):/).captures.first
+      matches = binding['bindinginformation'].match(/^(?<ip_dns>.+):(?<port>\d*):(?<host_header>(.*))/)
+      return matches[:ip_dns], matches[:port], matches[:host_header]
     end
   end
 end

--- a/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_newwebsite.ps1.erb
@@ -1,3 +1,5 @@
+<% ip_dns, port, host_header = resource.provider.binding_information %>
+
 $resource = @{
   name            = '<%= "#{resource[:name]}" %>'
   ensure          = '<%= "#{resource[:ensure]}" %>'
@@ -11,7 +13,8 @@ $createParams = @{
   ApplicationPool = $resource.applicationpool
   Force           = $true
   ErrorAction     = 'Stop'
-<%= "port            = #{resource.provider.binding_port}" unless resource.provider.binding_port.nil? %>
+<%= "    port            = #{port}\n"          unless port.nil? -%>
+<%= "    HostHeader      = '#{host_header}'\n" unless host_header.nil? -%>
 }
 
 # If there are no other websites, specify the Id, otherwise an Index Out of Range error can be thrown


### PR DESCRIPTION
This change makes it possible to pass both the port number and the
hostname header value from the bindinginformation property to the
New-Website cmdlet when creating a new website.