### PR TITLE
(MODULES-6208) Should support Sensitive datatype

### DIFF
--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -92,6 +92,35 @@ describe 'iis_application_pool' do
       end
     end
 
+    context 'with a password wrapped in Sensitive() defined' do
+        before(:all) do
+          @pool_name = "#{SecureRandom.hex(10)}"
+          @manifest  = <<-HERE
+            iis_application_pool { '#{@pool_name}':
+              ensure    => 'present',
+              user_name => 'user',
+              password  => Sensitive('password'),
+            }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = resource('iis_application_pool', @pool_name)
+          end
+
+          puppet_resource_should_show('ensure', 'present')
+          puppet_resource_should_show('user_name', 'user')
+          puppet_resource_should_show('password', 'password')
+
+        after(:all) do
+          remove_app_pool(@pool_name)
+        end
+      end
+    end
+
     context 'with invalid' do
       # TestRail ID: C100019
       context 'state parameter defined' do

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -44,6 +44,40 @@ describe 'iis_virtual_directory' do
       end
     end
 
+    context 'with a password wrapped in Sensitive()' do
+      before(:all) do
+        @virt_dir_name = "#{SecureRandom.hex(10)}"
+        @manifest  = <<-HERE
+          file{ 'c:/foo':
+            ensure => 'directory'
+          }->
+          iis_virtual_directory { '#{@virt_dir_name}':
+            ensure       => 'present',
+            sitename     => '#{@site_name}',
+            physicalpath => 'c:\\foo',
+            user_name    => 'user',
+            password     => Sensitive('password'),
+          }
+        HERE
+      end
+
+      it_behaves_like 'an idempotent resource'
+
+      context 'when puppet resource is run' do
+        before(:all) do
+          @result = resource('iis_virtual_directory', @virt_dir_name)
+        end
+
+        puppet_resource_should_show('ensure', 'present')
+        puppet_resource_should_show('user_name', 'user')
+        puppet_resource_should_show('password', 'password')
+      end
+
+      after(:all) do
+        remove_vdir(@virt_dir_name)
+      end
+    end
+
     context 'can remove virtual directory' do
       before(:all) do
         @virt_dir_name = "#{SecureRandom.hex(10)}"


### PR DESCRIPTION
The module already supports passing the Sensitive datatype to password
parameters. This change adds tests to ensure that this functionality
is never accidently broken.