### PR TITLE
Revert "(IMAGES-795) 2008r2 template failing PowerShell module tests"

### DIFF
--- a/lib/puppet_x/templates/iis/init_ps.ps1
+++ b/lib/puppet_x/templates/iis/init_ps.ps1
@@ -748,8 +748,6 @@ function Start-PipeServer
     $Encoding
   )
 
-  Add-Type -AssemblyName "System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-
   # this does not require versioning in the payload as client / server are tightly coupled
   $server = New-Object System.IO.Pipes.NamedPipeServerStream($CommandChannelPipeName,
     [System.IO.Pipes.PipeDirection]::InOut)


### PR DESCRIPTION
Reverting this PR to remove the specific version number in the `Add-Type` call.