### PR TITLE
(MODULES-6928) Fix Pipe Server on Win 2008r2

### DIFF
--- a/lib/puppet_x/templates/iis/init_ps.ps1
+++ b/lib/puppet_x/templates/iis/init_ps.ps1
@@ -748,6 +748,8 @@ function Start-PipeServer
     $Encoding
   )
 
+  Add-Type -AssemblyName System.Core
+
   # this does not require versioning in the payload as client / server are tightly coupled
   $server = New-Object System.IO.Pipes.NamedPipeServerStream($CommandChannelPipeName,
     [System.IO.Pipes.PipeDirection]::InOut)


### PR DESCRIPTION
The newest image for Windows 2008r2 is exhibiting different behavior
for loading .NET assemblies than we have seen in the past. The
System.Core assembly is not loaded into the PowerShell host process by
default any longer. This causes the init.ps1 script in the module to
to fail to start a Pipe Server to receive PowerShell scripts to be
executed. This change always attempts to load the System.Core
assembly prior to creating the pipe server object. Explicity loading the
assembly fixes the issue and the newest image becomes usable again.