### PR TITLE
MODULES-6947: Add bindings

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -100,19 +100,19 @@ Puppet::Type.newtype(:iis_application) do
 
   newproperty(:enabledprotocols) do
     desc 'The comma-delimited list of enabled protocols for the application.
-          Valid protocols are: \'http\', \'https\', \'net.pipe\'.'
+          Valid protocols are: \'http\', \'https\', \'net.pipe\', \'net.tcp\', \'net.msmq\', \'msmq.formatname\'.'
     validate do |value|
       return if value.nil?
       unless value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string")
       end
 
-      fail("Invalid value ''. Valid values are http, https, net.pipe") if value.empty?
+      fail("Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname") if value.empty?
 
       protocols = value.split(',')
       protocols.each do |protocol|
-        unless ['http', 'https', 'net.pipe'].include?(protocol)
-          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe")
+        unless ['http', 'https', 'net.pipe', 'net.tcp', 'net.msmq', 'msmq.formatname'].include?(protocol)
+          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname")
         end
       end
     end

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -76,18 +76,18 @@ Puppet::Type.newtype(:iis_site) do
     desc "The protocols enabled for the site. If 'https' is specified, 'http' is
           implied. If no value is provided, then this setting is disabled. Can
           be a comma delimited list of protocols. Valid protocols are: 'http',
-          'https', 'net.pipe'."
+          'https', 'net.pipe', 'net.tcp', 'net.msmq', 'msmq.formatname'."
     validate do |value|
       unless value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string")
       end
-      
-      fail("Invalid value ''. Valid values are http, https, net.pipe") if value.empty?
-      
+
+      fail("Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname") if value.empty?
+
       protocols = value.split(',')
       protocols.each do |protocol|
-        unless ['http', 'https', 'net.pipe'].include?(protocol)
-          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe")
+        unless ['http', 'https', 'net.pipe', 'net.tcp', 'net.msmq', 'msmq.formatname'].include?(protocol)
+          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname")
         end
       end
     end
@@ -126,8 +126,8 @@ Puppet::Type.newtype(:iis_site) do
       unless (['protocol','bindinginformation'] - value.keys).empty?
           fail("All bindings must specify protocol and bindinginformation values")
       end
-      unless ["http","https","net.pipe"].include?(value['protocol'])
-          fail("Invalid value '#{value}'. Valid values are http, https, net.pipe")
+      unless ["http","https","net.pipe","net.tcp","net.msmq","msmq.formatname"].include?(value['protocol'])
+          fail("Invalid value '#{value}'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname")
       end
 
       if ["http","https"].include?(value['protocol'])
@@ -138,9 +138,21 @@ Puppet::Type.newtype(:iis_site) do
           unless value["bindinginformation"].match(%r{^[^:]+$})
           fail("bindinginformation for net.pipe protocol must be of the format 'hostname'")
           end
+      elsif ["net.tcp"].include?(value['protocol'])
+          unless value["bindinginformation"].match(%r{^\d+:.*})
+          fail("bindinginformation for net.tcp protocol must be of the format '(ip|*):1-65535:hostname'")
+          end
+      elsif ["net.msmq"].include?(value['protocol'])
+          unless value["bindinginformation"].match(%r{^[^:]+$})
+          fail("bindinginformation for net.msmq protocol must be of the format 'hostname'")
+          end
+      elsif ["msmq.formatname"].include?(value['protocol'])
+          unless value["bindinginformation"].match(%r{^[^:]+$})
+          fail("bindinginformation for msmq.formatname protocol must be of the format 'hostname'")
+          end
       end
 
-      if ["http","net.pipe"].include?(value["protocol"]) and (value["sslflags"] or value["certificatehash"] or value["certificatestorename"])
+      if ["http","net.pipe","net.tcp","net.msmq","msmq.formatname"].include?(value["protocol"]) and (value["sslflags"] or value["certificatehash"] or value["certificatestorename"])
         fail("#{value["bindinginformation"]}: sslflags, certificatehash, and certificatestorename are not valid when protocol is http or net.pipe")
       end
       if value["protocol"] == "https"
@@ -203,7 +215,7 @@ Puppet::Type.newtype(:iis_site) do
         raise ArgumentError, "A non-empty serviceautostartprovidertype name must be specified."
       end
     end
-    
+
   end
 
   newproperty(:preloadenabled, :boolean => true) do
@@ -369,11 +381,11 @@ Puppet::Type.newtype(:iis_site) do
         fail("Cannot specify logflags when logformat is not W3C")
       end
     end
-    
+
     if self[:serviceautostartprovidername]
       fail("Must specify serviceautostartprovidertype as well as serviceautostartprovidername") unless self[:serviceautostartprovidertype]
     end
-    
+
     if self[:serviceautostartprovidertype]
       fail("Must specify serviceautostartprovidername as well as serviceautostartprovidertype") unless self[:serviceautostartprovidername]
     end

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -68,7 +68,7 @@ describe 'iis_application' do
     end
     it { expect(subject[:physicalpath]).to eq 'C:\test' }
   end
-  
+
   describe 'parameter :applicationpool' do
     [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
       context "when '#{value}'" do
@@ -188,13 +188,13 @@ describe 'iis_application' do
       let(:params) do
         {
           title: 'foo\bar',
-          enabledprotocols: 'http,https,net.pipe',
+          enabledprotocols: 'http,https,net.pipe,net.tcp,net.msmq,msmq.formatname',
         }
       end
-      it { expect(subject[:enabledprotocols]).to eq('http,https,net.pipe') }
+      it { expect(subject[:enabledprotocols]).to eq('http,https,net.pipe,net.tcp,net.msmq,msmq.formatname') }
     end
     context 'should not allow nil' do
-      let(:params) do 
+      let(:params) do
         {
           title: 'foo\bar',
           enabledprotocols: nil,
@@ -203,22 +203,22 @@ describe 'iis_application' do
       it { expect{subject}.to raise_error(Puppet::Error, /Got nil value for enabledprotocols/) }
     end
     context 'should not allow empty' do
-      let(:params) do 
+      let(:params) do
         {
           title: 'foo\bar',
           enabledprotocols: '',
         }
       end
-      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe/) }
+      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/) }
     end
     context 'should not accept invalid string value' do
-      let(:params) do 
+      let(:params) do
         {
           title: 'foo\bar',
           enabledprotocols: 'woot',
         }
       end
-      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe/) }
+      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/) }
     end
   end
 end

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -181,20 +181,23 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:enabledprotocols] = ''
-      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe/)
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/)
     end
 
     it "should accept valid string value" do
-      resource[:enabledprotocols] = ['http','https','net.pipe']
+      resource[:enabledprotocols] = ['http','https','net.pipe','net.tcp','net.msmq','msmq.formatname']
       resource[:enabledprotocols] = 'http'
       resource[:enabledprotocols] = 'https'
       resource[:enabledprotocols] = 'net.pipe'
+      resource[:enabledprotocols] = 'net.tcp'
+      resource[:enabledprotocols] = 'net.msmq'
+      resource[:enabledprotocols] = 'msmq.formatname'
     end
 
     it "should not accept invalid string value" do
       expect {
         resource[:enabledprotocols] = 'woot'
-      }.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe/)
+      }.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/)
     end
   end
 


### PR DESCRIPTION
Add support for net.tcp, net.msmq and msmq.formatname bindings
Currently supports only http, https and net.pipe bindings
Tested on IIS v7.5 running on Windows 2008 R2