### PR TITLE
(MODULES-7174) Added update method to fix parent provider flush

### DIFF
--- a/lib/puppet/provider/iis_feature/default.rb
+++ b/lib/puppet/provider/iis_feature/default.rb
@@ -37,6 +37,10 @@ Puppet::Type.type(:iis_feature).provide(:default, parent: Puppet::Provider::IIS_
     Puppet.debug "Powershell create response was '#{result}'"
   end
 
+  def update
+    Puppet.debug "Updating #{@resource[:name]}"
+  end
+
   def destroy
     raise Puppet::Error, "iis_feature can only be used to install IIS features. '#{resource[:name]}' is not an IIS feature" unless PuppetX::IIS::Features.is_iis_feature?(resource[:name])
 


### PR DESCRIPTION
When ensuing the removal of an iis_feature, it fails after the removal. This fails because every provider based off the iis_powershell provider requires the update method. Update is being called in the flush method of the parent. To re-mediate it this, I just put an empty method.

The code below produces the error below:
```puppet
iis_feature { 'Web-Basic-Auth':
  ensure => 'absent',
}
```
```bash
Could not evaluate: undefined local variable or method `update' for Iis_feature[Web-Basic-Auth]
```