### PR TITLE
(MAINT) Fix Powershell Manager Test

### DIFF
--- a/spec/integration/puppet_x/puppetlabs/iis/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/iis/powershell_manager_spec.rb
@@ -67,6 +67,12 @@ describe PuppetX::IIS::PowerShellManager,
           expected_error = /Failure waiting for PowerShell process (\d+) to start pipe server/
           expect(e.message).to match expected_error
           pid = expected_error.match(e.message)[1].to_i
+
+          # We want to make sure that enough time has elapsed since the manager called kill
+          # for the OS to finish killing the process and doing all of it's cleanup.
+          # We have found that without an appropriate wait period, the kill call below
+          # can return unexpected results and fail the test.
+          sleep(1)
           expect{Process.kill(0, pid)}.to raise_error(Errno::ESRCH)
         end
       end


### PR DESCRIPTION
As per MODULES-7033, this change fixes a test in powershell_manager_spec
that causes the CI pipeline to erroneously fail on some test runs
because of a race condition in the calls to Process.kill(). Refer to
commit 94865de in puppetlabs-powershell for the corresponding fix in
that module.