### PR TITLE
(MAINT) Fix Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,22 @@ $iis_features = ['Web-WebServer','Web-Scripting-Tools']
 
 iis_feature { $iis_features:
   ensure => 'present',
-} ->
+}
+
+# Delete the default website to prevent a port binding conflict.
+iis_site {'Default Web Site':
+  ensure  => absent,
+  require => Iis_feature['Web-WebServer'],
+}
 
 iis_site { 'minimal':
   ensure          => 'started',
   physicalpath    => 'c:\\inetpub\\minimal',
   applicationpool => 'DefaultAppPool',
-  require         => File['minimal'],
+  require         => [
+    File['minimal'],
+    Iis_site['Default Web Site']
+  ],
 }
 
 file { 'minimal':


### PR DESCRIPTION
Prior to this change, the first example in the readme me would always
fail. The example failed to either delete or disable the default website
'Default Web Site' that is created when installing the IIS feature.
Another approach might have been to bind the 'minimal' site to another
port, but that could have made the example more in depth into IIS
concepts than needed for the very first example.