### PR TITLE
(MODULES-6947) Add additional protocols

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -100,19 +100,19 @@ Puppet::Type.newtype(:iis_application) do
 
   newproperty(:enabledprotocols) do
     desc 'The comma-delimited list of enabled protocols for the application.
-          Valid protocols are: \'http\', \'https\', \'net.pipe\'.'
+          Valid protocols are: \'http\', \'https\', \'net.pipe\', \'net.tcp\', \'net.msmq\', \'msmq.formatname\'.'
     validate do |value|
       return if value.nil?
       unless value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string")
       end
 
-      fail("Invalid value ''. Valid values are http, https, net.pipe") if value.empty?
+      fail("Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname") if value.empty?
 
       protocols = value.split(',')
       protocols.each do |protocol|
-        unless ['http', 'https', 'net.pipe'].include?(protocol)
-          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe")
+        unless ['http', 'https', 'net.pipe', 'net.tcp', 'net.msmq', 'msmq.formatname'].include?(protocol)
+          fail("Invalid protocol '#{protocol}'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname")
         end
       end
     end

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -68,7 +68,7 @@ describe 'iis_application' do
     end
     it { expect(subject[:physicalpath]).to eq 'C:\test' }
   end
-  
+
   describe 'parameter :applicationpool' do
     [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
       context "when '#{value}'" do
@@ -188,13 +188,13 @@ describe 'iis_application' do
       let(:params) do
         {
           title: 'foo\bar',
-          enabledprotocols: 'http,https,net.pipe',
+          enabledprotocols: 'http,https,net.pipe,net.tcp,net.msmq,msmq.formatname',
         }
       end
-      it { expect(subject[:enabledprotocols]).to eq('http,https,net.pipe') }
+      it { expect(subject[:enabledprotocols]).to eq('http,https,net.pipe,net.tcp,net.msmq,msmq.formatname') }
     end
     context 'should not allow nil' do
-      let(:params) do 
+      let(:params) do
         {
           title: 'foo\bar',
           enabledprotocols: nil,
@@ -203,22 +203,22 @@ describe 'iis_application' do
       it { expect{subject}.to raise_error(Puppet::Error, /Got nil value for enabledprotocols/) }
     end
     context 'should not allow empty' do
-      let(:params) do 
+      let(:params) do
         {
           title: 'foo\bar',
           enabledprotocols: '',
         }
       end
-      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe/) }
+      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/) }
     end
     context 'should not accept invalid string value' do
-      let(:params) do 
+      let(:params) do
         {
           title: 'foo\bar',
           enabledprotocols: 'woot',
         }
       end
-      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe/) }
+      it { expect{subject}.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/) }
     end
   end
 end

--- a/spec/unit/puppet/type/iis_site_spec.rb
+++ b/spec/unit/puppet/type/iis_site_spec.rb
@@ -181,20 +181,23 @@ describe Puppet::Type.type(:iis_site) do
     it "should not allow empty" do
       expect {
         resource[:enabledprotocols] = ''
-      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe/)
+      }.to raise_error(Puppet::ResourceError, /Invalid value ''. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/)
     end
 
     it "should accept valid string value" do
-      resource[:enabledprotocols] = ['http','https','net.pipe']
+      resource[:enabledprotocols] = ['http','https','net.pipe','net.tcp','net.msmq','msmq.formatname']
       resource[:enabledprotocols] = 'http'
       resource[:enabledprotocols] = 'https'
       resource[:enabledprotocols] = 'net.pipe'
+      resource[:enabledprotocols] = 'net.tcp'
+      resource[:enabledprotocols] = 'net.msmq'
+      resource[:enabledprotocols] = 'msmq.formatname'
     end
 
     it "should not accept invalid string value" do
       expect {
         resource[:enabledprotocols] = 'woot'
-      }.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe/)
+      }.to raise_error(Puppet::ResourceError, /Invalid protocol 'woot'. Valid values are http, https, net.pipe, net.tcp, net.msmq, msmq.formatname/)
     end
   end
 


### PR DESCRIPTION
Add support for net.tcp, net.msmq and msmq.formatname protocols. Module
currently supports only http, https and net.pipe bindings. No acceptance tests
were added. After discussion it was decided that since all possible bindings are
not currently tested, and since no changes were made to providers, only types,
that there was no real value add to adding acceptance tests for these new
protocols.