### PR TITLE
pdksync - (MODULES-7658) use beaker4 in puppet-module-gems

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+require 'beaker-puppet'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker-rspec/spec_helper'
 require 'beaker/puppet_install_helper'
@@ -8,6 +10,7 @@ require 'beaker/module_install_helper'
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 run_puppet_install_helper
+configure_type_defaults_on(hosts)
 install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ /pe/i
 
 # Install iis module either from source or from staging forge if given correct env variables


### PR DESCRIPTION
(MODULES-7658) use beaker4 in puppet-module-gems
pdk version: `1.6.0` 
