### PR TITLE
(MODULES-5493) Manage Two Same Name Appications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Fixed
+
+- `iis_application` cannot manage two applications with the same name under different web sites ([MODULES-5493](https://tickets.puppetlabs.com/browse/MODULES-5493))
+- `applicationname` parameter cannot start with '/' character. Fixed as a by product of [MODULES-5493](https://tickets.puppetlabs.com/brows/MODULES-5493).
+
+### Changed
+
+- The direction of slashes used in the title of an `iis_application` resource no longer matters. This is true both for the slash that separates the `sitename` portion of the title from the `applicationname` name, and also for the path separator used if the application path is nested deeply in folders under the web site.
+
 ## [4.4.0] - 2018-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,7 +172,43 @@ iis_virtual_directory { 'vdir':
 
 Allows creation of a new IIS Application and configuration of application parameters.
 
-The iis_application type uses a composite namevar for applicationname and sitename to uniquely identify a declaration. To use this successfully, put both the sitename and the applicationname in the title. Puppet will build the catalog using the composite of the two values, while still using the correct value for the applicationname when creating the IIS application.  It requires a `\` in between the `sitename` and `applicationname`, for example, `iis_application { '#{@site_name}\\#{@app_name}'`. 
+The iis_application type creates IIS Applications from directories and virtual directories, within an IIS Website. To use this type you must specify the name of a website, and then the path within the website where you would like to host an application. To do this you can use either the title only or you can use the application name and the sitename parameters separately or in combination with the title. You may also omit the sitename if you are converting an virtual directory to an application, as that parameter will already tell the provider the name of the site.
+
+```puppet
+iis_application {"$site_name\\$app_name":
+  ensure => present,
+}
+
+iis_application { $app_name:
+  ensure   => present,
+  sitename => $site_name,
+}
+
+iis_application {'myAwesomeApp':
+  ensure          => present,
+  applicationname => $app_name, # <-- Does not need to match the title
+  sitename        => $site_name
+}
+
+iis_application {'importantApplication':
+  ensure => present,
+  virtual_directory => 'IIS:\\Sites\\important_website\\importantApplication'
+}
+```
+
+To manage two applications of the same name but in different websites on the same IIS instance, you will need to ensure that both the sitename and the applicationname are in the resource title, to ensure that Puppet can refer to them uniquely when it compiles the catalog, as in the example below:
+
+```puppet
+iis_application {'site1/api':
+  ensure => present,
+}
+
+iis_application {'site2/api':
+  ensure => present,
+}
+```
+
+*note: Both forward slashes and back slashes can be used in any combination.
 
 #### Properties/Parameters
 
@@ -198,7 +234,7 @@ The name of the application pool for the application.
 
 #### `virtual_directory`
 
-The IIS Virtual Directory to convert to an application on create. Similar to iis_application, iis_virtual_directory uses composite namevars.
+The IIS Virtual Directory to convert to an application on create. Path must be in the form of `IIS:\\Sites\\<sitename>\\<path\\to\\virtdir>`.
 
 #### `sslflags`
 

--- a/lib/puppet/provider/templates/webadministration/newapplication.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/newapplication.ps1.erb
@@ -1,6 +1,6 @@
 $resource = @{
-  name            = '<%= "#{resource[:applicationname]}" %>'
-  site            = '<%= "#{resource[:sitename]}" %>'
+  name            = '<%= "#{resource.provider.app_name}" %>'
+  site            = '<%= "#{resource.provider.class.find_sitename(resource)}" %>'
   physicalpath    = '<%= "#{resource[:physicalpath]}" %>'
   applicationpool = '<%= "#{resource[:applicationpool]}" %>'
 }

--- a/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
@@ -39,6 +39,7 @@ describe 'iis_application provider' do
         {
           title: 'foo\bar',
           physicalpath: 'C:\exist',
+          sitename: 'foo',
         }
       end
       before :each do
@@ -52,7 +53,7 @@ describe 'iis_application provider' do
     let(:params) do
       {
         title: 'foo\bar',
-        virtual_directory: 'IIS:\exists',
+        virtual_directory: 'IIS:\Sites\exists\vdir',
       }
     end
     before :each do

--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -4,19 +4,6 @@ describe 'iis_application' do
   subject do
     Puppet::Type.type(:iis_application).new(params)
   end
-  context 'specifying compound title' do
-    let(:params) do
-      { title: 'foo\bar' }
-    end
-    it { expect(subject[:sitename]).to eq 'foo' }
-    it { expect(subject[:applicationname]).to eq 'bar' }
-  end
-  context 'specifying title without sitename' do
-    let(:params) do
-      { title: 'bar' }
-    end
-    it { expect{subject}.to raise_error(Puppet::Error, /sitename/) }
-  end
   context 'specifying title with sitename' do
     let(:params) do
       {
@@ -46,6 +33,15 @@ describe 'iis_application' do
       }
     end
     it { expect(subject[:virtual_directory]).to eq 'IIS:\Sites\foo\bar' }
+  end
+  context 'specifying virtual_directory with no provider path' do
+    let(:params) do
+      {
+        title: 'foo\bar',
+        virtual_directory: 'foo\bar',
+      }
+    end
+    it {expect(subject[:virtual_directory]).to eq 'IIS:/Sites/foo\bar'}
   end
   context 'specifying authenticationinfo' do
     let(:params) do


### PR DESCRIPTION
This commit fixes a bug in the way this module uses the composite name key
feature. Prior to this change the `sitename` property was specified as
a part of the composite key. Unfortunately, properties are not valid
components of a composite key and the directive was ignored. This meant
that in truth there was only one attribute considered for the naming key,
and thus for uniqueness, which was the `applicationname` parameter.

This change removes the composite namevar functionality. The provider
has been modified such that if a user adds the site name to the applicationname
parameter, it can tell what part of the applicationname actually refers to the
sitename and handle the title accordingly.

This allows users to define applicationname's that include the sitename so
that uniqueness can be maintained for catalog compilation, but the provider
knows the name of the application to be created and isn't confused.