### PR TITLE
(MAINT) remove Testrail ID comments

### DIFF
--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper_acceptance'
 
 describe 'iis_application_pool' do
   context 'when configuring an application pool' do
-    # TestRail ID: C99574
     context 'with default parameters' do
       before(:all) do
         @pool_name = "#{SecureRandom.hex(10)}"
@@ -29,7 +28,6 @@ describe 'iis_application_pool' do
     end
 
     context 'with valid parameters defined' do
-      # TestRail ID: C100018
       before(:all) do
         @pool_name = "#{SecureRandom.hex(10)}"
         @manifest  = <<-HERE
@@ -126,7 +124,6 @@ describe 'iis_application_pool' do
     end
 
     context 'with invalid' do
-      # TestRail ID: C100019
       context 'state parameter defined' do
         before(:all) do
           @pool_name = "#{SecureRandom.hex(10)}"
@@ -153,7 +150,6 @@ describe 'iis_application_pool' do
         end
       end
 
-      # TestRail ID: C100020
       context 'managed_pipeline_mode parameter defined' do
         before(:all) do
           @pool_name = "#{SecureRandom.hex(10)}"
@@ -182,7 +178,6 @@ describe 'iis_application_pool' do
     end
   end
 
-  # TestRail ID: C100021
   context 'when starting a stopped application pool' do
     before(:all) do
       @pool_name = "#{SecureRandom.hex(10)}"
@@ -212,7 +207,6 @@ describe 'iis_application_pool' do
     }
   end
 
-  # TestRail ID: C99576
   context 'when removing an application pool' do
     before(:all) do
       @pool_name = "#{SecureRandom.hex(10)}"

--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -28,7 +28,6 @@ describe 'iis_application' do
 
       it_behaves_like 'an idempotent resource'
 
-      # TestRail ID: C100060
       context 'when puppet resource is run' do
         before(:all) do
           @result = on(default, puppet('resource', 'iis_application', "#{@site_name}\\\\#{@app_name}"))
@@ -46,7 +45,6 @@ describe 'iis_application' do
       end
     end
 
-    # TestRail ID: C100061
     context 'with virtual_directory' do
       before(:all) do
         @site_name = SecureRandom.hex(10)
@@ -208,7 +206,6 @@ describe 'iis_application' do
     end
   end
 
-  # TestRail ID: C100062
   context 'when setting' do
     skip 'sslflags - blocked by MODULES-5561' do
       before(:all) do
@@ -298,7 +295,6 @@ describe 'iis_application' do
     end
   end
 
-  # TestRail ID: C100063
   context 'when removing an application' do
     before(:all) do
       @site_name = SecureRandom.hex(10)

--- a/spec/acceptance/iis_feature_spec.rb
+++ b/spec/acceptance/iis_feature_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper_acceptance'
 
 describe 'iis_feature' do
   context 'when managing features' do
-    # TestRail ID: C100065
     context 'with default parameters' do
       before(:all) do
         @feature = 'Web-Scripting-Tools'
@@ -24,7 +23,6 @@ describe 'iis_feature' do
       end
     end
 
-    # TestRail ID: C100066
     context 'with invalid' do
       context 'name parameter defined' do
         before(:all) do

--- a/spec/acceptance/iis_minimal_config_spec.rb
+++ b/spec/acceptance/iis_minimal_config_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper_acceptance'
 
-# TestRail ID: C100067
 describe 'a minimal IIS config:' do
   before(:all) do
     @manifest = <<-EOF

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -7,7 +7,6 @@ describe 'iis_site' do
   end
 
   context 'when configuring a website' do
-    # TestRail ID: C100068
     context 'with basic required parameters' do
       before (:all) do
         create_path('C:\inetpub\basic')
@@ -37,7 +36,6 @@ describe 'iis_site' do
       end
     end
 
-    # TestRail ID: C100069
     context 'with all parameters specified' do
       context 'using W3C log format, logflags and logtruncatesize' do
         before (:all) do
@@ -172,7 +170,6 @@ describe 'iis_site' do
         end
       end
 
-      # TestRail ID: C100070
       context 'using non-W3C log format and logtperiod' do
         before (:all) do
           create_path('C:\inetpub\tmp')
@@ -239,7 +236,6 @@ describe 'iis_site' do
       end
     end
 
-    # TestRail ID: C100071
     context 'can change site state from' do
       context 'stopped to started' do
         before (:all) do
@@ -271,7 +267,6 @@ describe 'iis_site' do
         end
       end
 
-      # TestRail ID: C100072
       context 'started to stopped' do
         before (:all) do
           create_path('C:\inetpub\tmp')
@@ -302,7 +297,6 @@ describe 'iis_site' do
         end
       end
 
-      # TestRail ID: C100073
       context 'started to absent' do
         before (:all) do
           @site_name = "#{SecureRandom.hex(10)}"
@@ -331,7 +325,6 @@ describe 'iis_site' do
     end
 
     context 'with invalid value for' do
-      # TestRail ID: C100074
       context 'logformat' do
         before(:all) do
           create_path('C:\inetpub\wwwroot')
@@ -349,7 +342,6 @@ describe 'iis_site' do
         it_behaves_like 'a failing manifest'
       end
 
-      # TestRail ID: C100075
       context 'logperiod' do
         before(:all) do
           create_path('C:\inetpub\wwwroot')
@@ -373,7 +365,6 @@ describe 'iis_site' do
     end
 
     context 'can changed previously set value' do
-      # TestRail ID: C100076
       context 'physicalpath' do
         before(:all) do
           @site_name = "#{SecureRandom.hex(10)}"
@@ -430,7 +421,6 @@ describe 'iis_site' do
         end
       end
 
-      # TestRail ID: C100077
       context 'bindings' do
         before(:all) do
           create_path('C:\inetpub\new')
@@ -493,7 +483,6 @@ describe 'iis_site' do
         end
       end
 
-      # TestRail ID: C100078
       context 'enabledprotocols' do
         before(:all) do
           create_path('C:\inetpub\new')
@@ -532,7 +521,6 @@ describe 'iis_site' do
         end
       end
 
-      # TestRail ID: C100079
       context 'logflags' do
         before(:all) do
           create_path('C:\inetpub\new')


### PR DESCRIPTION
We no longer use Testrail in any capacity, so I've removed the comments linking tests to Testrail ID's.