### PR TITLE
(MODULES-8346) Case Sensitive Paths

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -2,6 +2,7 @@ require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_application) do
   @doc = "Allows creation of a new IIS Application and configuration of
@@ -31,7 +32,7 @@ Puppet::Type.newtype(:iis_application) do
     desc 'The name of the site for the application.'
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the application directory. This path must be
           fully qualified.'
     validate do |value|

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -1,6 +1,7 @@
 require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
+require_relative '../../puppet_x/puppetlabs/iis/property/path'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Allows creation of a new IIS Web Site and configuration of site
@@ -51,7 +52,7 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:physicalpath) do
+  newproperty(:physicalpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'The physical path to the site directory. This path must be fully
           qualified.'
     validate do |value|
@@ -253,7 +254,7 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:logpath) do
+  newproperty(:logpath, :parent => PuppetX::PuppetLabs::IIS::Property::Path) do
     desc 'Specifies the physical path to place the log file'
     validate do |value|
       if value.nil? or value.empty?

--- a/lib/puppet_x/puppetlabs/iis/property/path.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/path.rb
@@ -8,6 +8,10 @@ module PuppetX
               fail("#{self.name.to_s} should be a path (local or UNC) not '#{value}'")
             end
           end
+
+          def property_matches?(current, desired)
+            current.downcase == desired.downcase
+          end
         end
       end
     end

--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -36,6 +36,23 @@ describe 'iis_application' do
         include_context 'with a puppet resource run'
         puppet_resource_should_show('physicalpath', 'C:\inetpub\basic')
         puppet_resource_should_show('applicationpool', 'DefaultAppPool')
+
+        context 'when case is changed in a manifest' do
+          before(:all) do
+            @manifest = <<-HERE
+              iis_application { '#{@app_name}':
+                ensure       => 'present',
+                sitename     => '#{@site_name}',
+                # Change the capitalization of the T to see if it breaks.
+                physicalpath => 'C:\\ineTpub\\basic',
+              }
+            HERE
+          end
+
+          it 'should run with no changes' do
+            execute_manifest(@manifest, :catch_changes => true)
+          end
+        end
       end
 
       after(:all) do

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -134,6 +134,23 @@ describe 'iis_site' do
           it 'should have a binding to 443' do
             expect(@result.stdout).to match(/'bindinginformation' => '\*:443:www.puppet.local'/)
           end
+
+          context 'when capitalization is changed in path parameters' do
+            before (:all) do
+              @manifest = <<-HERE
+                iis_site { '#{@site_name}':
+                  ensure               => 'started',
+                  # Change capitalization to see if it break idempotency
+                  logpath              => 'C:\\ineTpub\\logs\\NewLogFiles',
+                  physicalpath         => 'C:\\ineTpub\\new',
+                }
+              HERE
+            end
+
+            it 'should run with no changes' do
+              execute_manifest(@manifest, :catch_changes => true)
+            end
+          end
         end
 
         after(:all) do

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -37,6 +37,23 @@ describe 'iis_virtual_directory' do
         end
 
         puppet_resource_should_show('ensure', 'present')
+
+        context 'when capitalization of paths change' do
+          before(:all) do
+            @manifest  = <<-HERE
+              iis_virtual_directory { '#{@virt_dir_name}':
+                ensure       => 'present',
+                sitename     => '#{@site_name}',
+                # Change capitalization to see if it breaks idempotency
+                physicalpath => 'c:\\Foo'
+              }
+            HERE
+          end
+
+          it 'should run with no changes' do
+            execute_manifest(@manifest, :catch_changes => true)
+          end
+        end
       end
 
       after(:all) do


### PR DESCRIPTION
This change overrides the property_insync method in the custom type
`Path` type in lib\puppet_x\puppetlabs\iis\property\path.rb. The new
implementation ensures that values for is and should are compared in a
case insensitive manner. Values are not munged, so the proper case
provided by the user is still stored when the object is created, but
this avoids erroneous changes being logged if someone changes the value
in the manifest and no change should actually be made.

Prior to this change, if someone simply changes the case of a path in
a manifest, a corrective change would be logged when the user expectation
would have been an idempotent run with no changes logged because Windows
file paths are not case sensitive.