### PR TITLE
(MODULES-6061) Fix virtual directory update

### DIFF
--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -50,8 +50,7 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
 
     cmd = []
 
-    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'site' -Value '#{@resource[:sitename]}';" if @resource[:sitename]
-    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'physicalpath' -Value '#{@resource[:physicalpath]}';" if @resource[:physicalpath]
+    cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'physicalPath' -Value '#{@resource[:physicalpath]}';" if @resource[:physicalpath]
     cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'application' -Value '#{@resource[:application]}';" if @resource[:application]
     cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'userName' -Value '#{@resource[:user_name]}';" if @resource[:user_name]
     cmd << "Set-ItemProperty -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' -Name 'password' -Value '#{escape_string(@resource[:password])}';" if @resource[:password]

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -21,6 +21,9 @@ describe 'iis_virtual_directory' do
           file{ 'c:/foo':
             ensure => 'directory'
           }->
+          file{ 'c:/foo2':
+          ensure => 'directory'
+          }->
           iis_virtual_directory { '#{@virt_dir_name}':
             ensure       => 'present',
             sitename     => '#{@site_name}',
@@ -53,6 +56,28 @@ describe 'iis_virtual_directory' do
           it 'should run with no changes' do
             execute_manifest(@manifest, :catch_changes => true)
           end
+        end
+      end
+
+      context 'when physical path changes' do
+        before(:all) do
+          @manifest  = <<-HERE
+          iis_virtual_directory { '#{@virt_dir_name}':
+            ensure       => 'present',
+            sitename     => '#{@site_name}',
+            physicalpath => 'c:\\foo2'
+          }
+          HERE
+        end
+
+        it_behaves_like 'an idempotent resource'
+
+        context 'when puppet resource is run' do
+          before(:all) do
+            @result = resource('iis_virtual_directory', @virt_dir_name)
+          end
+
+          puppet_resource_should_show('physicalpath', 'c:\\foo2')
         end
       end
 


### PR DESCRIPTION
This change fixes the module's ability to update the physical path that
a virtual directory points to. This fix is in two parts.

First, the line that attempted to update the sitename a virtual
directory belongs to had to be removed. The site name for a virtual
directory is not a property of the virtual directory when looked at from
the point of view of the xml configuration file. Instead the virtual
directory is a child node of the site. This means that
`Set-ItemProperty` cannot be used to move a virtual directory from one
site to another. Worse, since that property does not actually exist, it
will always result in an error.

Second, since `Set-ItemProperty` in this case is a helper function for
xml manipulation, it ended up being case sensitive. The casing of the
property name `physicalPath` was accidentally spelled `physicalpath`.
Unfortunately, the way this cmdlet works in this context, the missed
property name did not result in an error, and Puppet had no way of
knowing the property didn't match, and was led to believe the change had
been made successfully.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
