### PR TITLE
(MODULES-6080) Ensure virtualdir removal idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure removal of virtual directories is idempotent ([MODULES-6080](https://tickets.puppetlabs.com/browse/MODULES-6080)).
+
 ## [4.5.0] - 2018-10-23
 
 ### Fixed

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -62,16 +62,18 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
 
   def destroy
     Puppet.debug "Destroying #{@resource[:name]}"
-    cmd = []
-    cmd << "Remove-WebVirtualDirectory -Name \"#{@resource[:name]}\" "
-    cmd << "-Site \"#{@property_hash[:sitename]}\" "
-    cmd << "-Application \"#{@property_hash[:application]}\" "
-    cmd << "-ErrorAction Stop"
-    cmd = cmd.join
+    test = self.class.run("Test-Path -Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}'")
+    if test[:stdout].strip.downcase == 'true'
+      cmd = []
+      cmd << "Remove-Item " 
+      cmd << "-Path 'IIS:\\Sites\\#{@resource[:sitename]}\\#{@resource[:name]}' "
+      cmd << "-Recurse "
+      cmd << "-ErrorAction Stop "
+      cmd = cmd.join
 
-    result   = self.class.run(cmd)
-    Puppet.err "Error destroying virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
-
+      result   = self.class.run(cmd)
+      Puppet.err "Error destroying virtual directory: #{result[:errormessage]}" unless result[:exitcode] == 0
+    end
     @property_hash[:ensure] = :absent
   end
 

--- a/spec/support/utilities/iis_virtual_directory.rb
+++ b/spec/support/utilities/iis_virtual_directory.rb
@@ -9,7 +9,7 @@ def create_vdir(vdir_name, site = 'foo', path = 'C:\inetpub\wwwroot')
 end
 
 def remove_vdir(vdir_name, site = 'foo', path = 'C:\inetpub\wwwroot')
-  command = format_powershell_iis_command("Remove-WebVirtualDirectory -Name #{vdir_name} -Site #{@site} -PhysicalPath #{@path}")
+  command = format_powershell_iis_command("Remove-Item -Path 'IIS:\\Sites\\#{@site}\\#{@vdir_name}' -Recurse -ErrorAction Stop")
   on(default, command) if has_vdir(vdir_name)
 end
 


### PR DESCRIPTION
This commit adds the `Recurse` parameter to calls to the
`Remove-WebVirtualDirectory` function, ensuring removals
of folders which have subfolders and child items are
actually removed.

Prior to this commit those calls would prompt a confirmation
which the run cannot give, causing failures and flapping.