### PR TITLE
(MODULES-9087) Increase pipe timeout to 180s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- Increase the named pipe timeout to 180 seconds to prevent runs from failing waiting for a pipe to open ([MODULES-9087](https://tickets.puppetlabs.com/browse/MODULES-9087)).
+
 ### Fixed
 
 - Ensure ability to specify timespans which include days, such as `1.05:00:00` ([MODULES-8381]. (https://tickets.puppetlabs.com/browse/MODULES-8381)). Thanks, Trey Dockendorf ([@treydock](https://github.com/treydock))!

--- a/lib/puppet_x/puppetlabs/iis/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/iis/powershell_manager.rb
@@ -9,7 +9,7 @@ module PuppetX
     class PowerShellManager
       @@instances = {}
 
-      def self.instance(cmd, debug = false, pipe_timeout = 100)
+      def self.instance(cmd, debug = false, pipe_timeout = 180)
         key = cmd + debug.to_s
         manager = @@instances[key]
 
@@ -54,7 +54,7 @@ module PuppetX
         pipe_path = "\\\\.\\pipe\\#{named_pipe_name}"
         # wait for the pipe server to signal ready, and fail if no response in 10 seconds
 
-        # wait up to 30 seconds in 0.2 second intervals to be able to open the pipe
+        # wait up to 180 seconds in 0.2 second intervals to be able to open the pipe
         # If the pipe_timeout is ever specified as less than the sleep interval it will
         # never try to connect to a pipe and error out as if a timeout occurred.
         sleep_interval = 0.2


### PR DESCRIPTION
This commit increases the timeout for waiting on the named
pipe to open. This resolves issues where servers under
heavy load do not open the pipe quickly enough.