### PR TITLE
(MODULES-7820) Fix "No Managed Code" in app pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- Ensure setting `:managed_runtime_version` to `''` results in `iis_app_pool` being set to `No Managed Code` idempotently ([MODULES-7820](https://tickets.puppetlabs.com/browse/MODULES-7820)).
 - Ensure ability to specify timespans which include days, such as `1.05:00:00` ([MODULES-8381]. (https://tickets.puppetlabs.com/browse/MODULES-8381)). Thanks, Trey Dockendorf ([@treydock](https://github.com/treydock))!
 
 ## [4.5.1] - 2019-03-02

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ iis_application_pool { 'complete_site_app_pool':
 iis_application_pool {'test_app_pool':
     ensure                    => 'present',
     enable32_bit_app_on_win64 => true,
-    managed_runtime_version   => '""',
+    managed_runtime_version   => '',
     managed_pipeline_mode     => 'Classic',
     start_mode                => 'AlwaysRunning'
   }
@@ -334,6 +334,7 @@ Specifies the managed loader to use for pre-loading the the application pool. No
 #### `managed_runtime_version`
 
 Specifies the .NET Framework version that is used by the application pool.
+Specify an empty string (`''`) to set as 'No Managed Code.'
 
 #### `pass_anonymous_token`
 

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -101,7 +101,7 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
       pool_hash[:enable32_bit_app_on_win64]     = pool['enable32_bit_app_on_win64'].to_s.downcase
       pool_hash[:enable_configuration_override] = pool['enable_configuration_override'].to_s.downcase
       pool_hash[:managed_pipeline_mode]         = pool['managed_pipeline_mode']
-      pool_hash[:managed_runtime_version]       = pool['managed_runtime_version']
+      pool_hash[:managed_runtime_version]       = pool['managed_runtime_version'].nil? ? '' : pool['managed_runtime_version']
       pool_hash[:pass_anonymous_token]          = pool['pass_anonymous_token'].to_s.downcase
       pool_hash[:start_mode]                    = pool['start_mode']
       pool_hash[:queue_length]                  = pool['queue_length']

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -95,8 +95,9 @@ Puppet::Type.newtype(:iis_application_pool) do
   end
 
   newproperty(:managed_runtime_version) do
-    desc "Specifies the .NET Framework version to be used by the application pool"
-    newvalues('""','v1.1','v2.0','v4.0')
+    desc "Specifies the .NET Framework version to be used by the application pool.
+          Specify an empty string (`''`) to set as 'No Managed Code.'"
+    newvalues('','v1.1','v2.0','v4.0')
   end
 
   newproperty(:pass_anonymous_token, :boolean => true) do

--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -34,7 +34,7 @@ describe 'iis_application_pool' do
           iis_application_pool { '#{@pool_name}':
             ensure                  => 'present',
             managed_pipeline_mode   => 'Integrated',
-            managed_runtime_version => 'v4.0',
+            managed_runtime_version => '',
             state                   => 'Stopped'
           }
         HERE
@@ -51,7 +51,6 @@ describe 'iis_application_pool' do
 
         # Properties introduced in IIS 7.0 (Server 2008 - Kernel 6.1)
         puppet_resource_should_show('managed_pipeline_mode', 'Integrated')
-        puppet_resource_should_show('managed_runtime_version', 'v4.0')
         puppet_resource_should_show('state', 'Stopped')
         puppet_resource_should_show('auto_start', :true)
         puppet_resource_should_show('enable32_bit_app_on_win64', :false)


### PR DESCRIPTION
This commit updates the `iis_application_pool` type for the
`:managed_runtime_version` to accept an empty string, `''`,
to specify "No Managed Code" - prior to this commit the
definition was `'""'` which actually errors when specified
in PowerShell.

This commit further updates the documentation to be more
explicit about this and updates the acceptance tests to
verify this functionality.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
