### PR TITLE
(MODULES-7700) Ensure app pool state is idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+- Ensure setting `iis_application_pool` state is idempotent ([MODULES-7700](https://tickets.puppetlabs.com/browse/MODULES-7700)).
 - Ensure setting `:managed_runtime_version` to `''` results in `iis_app_pool` being set to `No Managed Code` idempotently ([MODULES-7820](https://tickets.puppetlabs.com/browse/MODULES-7820)).
 - Ensure ability to specify timespans which include days, such as `1.05:00:00` ([MODULES-8381]. (https://tickets.puppetlabs.com/browse/MODULES-8381)). Thanks, Trey Dockendorf ([@treydock](https://github.com/treydock))!
 

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -45,9 +45,9 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
       Puppet.debug "Changing #{@resource[:name]} to #{@resource[:state]}"
       case @resource[:state].downcase
       when :stopped
-        cmd << "Stop-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+        cmd << "If((Get-WebAppPoolState -Name \"#{@resource[:name]}\").Value -ne 'Stopped'){Stop-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop}"
       when :started
-        cmd << "Start-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop"
+        cmd << "If((Get-WebAppPoolState -Name \"#{@resource[:name]}\").Value -ne 'Started'){Start-WebAppPool -Name \"#{@resource[:name]}\" -ErrorAction Stop}"
       end
     end
 


### PR DESCRIPTION
Prior to this commit the call to start or stop an app pool
was made regardless of whether it is currently stopped or
started. On older versions of Windows this would sometimes
cause an error alerting that the app pool was already in
a stopped state.

This commit ensures the command runs if and only if the
app pool state needs to change. This prevents the error
from surfacing.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
