### PR TITLE
(MODULES-10361) sort https bindings first

### DIFF
--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -2,6 +2,7 @@ require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
 require_relative '../../puppet_x/puppetlabs/iis/property/path'
+require_relative '../../puppet_x/puppetlabs/iis/bindings'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Allows creation of a new IIS Web Site and configuration of site
@@ -170,6 +171,19 @@ Puppet::Type.newtype(:iis_site) do
         value['certificatehash'] = value['certificatehash'].upcase
       end
       value
+    end
+
+    def should
+      PuppetX::PuppetLabs::IIS::Bindings.sort_bindings(super)
+    end
+
+    def should=(values)
+      super
+      @should = PuppetX::PuppetLabs::IIS::Bindings.sort_bindings(@should)
+    end
+
+    def insync?(is)
+      PuppetX::PuppetLabs::IIS::Bindings.sort_bindings(is) == should
     end
   end
 

--- a/lib/puppet_x/puppetlabs/iis/bindings.rb
+++ b/lib/puppet_x/puppetlabs/iis/bindings.rb
@@ -1,0 +1,13 @@
+# The Puppet Extensions Module
+module PuppetX::PuppetLabs::IIS
+  # Bindings class
+  class Bindings
+    def self.sort_bindings(b)
+      if b.nil?
+        []
+      else
+        b.sort_by { |a| ((a['protocol'] == 'https') ? '0' : '1') + a['bindinginformation'] }
+      end
+    end
+  end
+end

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -64,6 +64,10 @@ describe 'iis_site', :suite_b do
                   'protocol'             => 'http',
                 },
                 {
+                  'bindinginformation'   => '*:8088:www.puppet.local',
+                  'protocol'             => 'http',
+                },
+                {
                   'bindinginformation'   => '*:443:www.puppet.local',
                   'certificatehash'      => '#{certificate_hash}',
                   'certificatestorename' => 'MY',
@@ -120,7 +124,7 @@ describe 'iis_site', :suite_b do
               ensure               => 'started',
               # Change capitalization to see if it break idempotency
               logpath              => 'C:\\ineTpub\\logs\\NewLogFiles',
-              physicalpath         => 'C:\\ineTpub\\new',
+              physicalpath         => 'C:\\ineTpub\\new'
             }
           HERE
           apply_manifest(manifest, catch_changes: true)


### PR DESCRIPTION
Fixes: [MODULES-10361](https://tickets.puppetlabs.com/browse/MODULES-10361)

When creating an `iis_site` resource, if non-ssl bindings come before ssl bindings, resource creation fails with an error similar to the following:

> `change from 'absent' to 'started' failed: Could not set 'started' on ensure: Error starting website: System.Management.Automation.CmdletInvocationException: Cannot find path 'IIS:\Sites\MyWebsite' because it does not exist.`

This patch sorts `https` bindings before non-`https` bindings.

