### PR TITLE
(MODULES-10362) handle authenticationinfo consistently

### DIFF
--- a/lib/puppet/type/iis_application.rb
+++ b/lib/puppet/type/iis_application.rb
@@ -3,6 +3,7 @@ require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
 require_relative '../../puppet_x/puppetlabs/iis/property/path'
+require_relative '../../puppet_x/puppetlabs/iis/property/authenticationinfo'
 
 Puppet::Type.newtype(:iis_application) do
   desc <<-DOC
@@ -78,14 +79,7 @@ Puppet::Type.newtype(:iis_application) do
     )
   end
 
-  newproperty(:authenticationinfo, parent: PuppetX::PuppetLabs::IIS::Property::Hash) do
-    desc 'Enable and disable IIS authentication schemas.'
-    def insync?(is)
-      should.reject { |k, v|
-        is[k] == v
-      }.empty?
-    end
-  end
+  newproperty(:authenticationinfo, parent: PuppetX::PuppetLabs::IIS::Property::AuthenticationInfo)
 
   newproperty(:enabledprotocols) do
     desc 'The comma-delimited list of enabled protocols for the application.

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -2,6 +2,7 @@ require 'puppet/parameter/boolean'
 require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/hash'
 require_relative '../../puppet_x/puppetlabs/iis/property/path'
+require_relative '../../puppet_x/puppetlabs/iis/property/authenticationinfo'
 
 Puppet::Type.newtype(:iis_site) do
   @doc = "Allows creation of a new IIS Web Site and configuration of site
@@ -346,20 +347,7 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  newproperty(:authenticationinfo) do
-    desc 'Enable and disable authentication schemas. Note: some schemas require
-          additional Windows features to be installed, for example windows
-          authentication. This type does not ensure a given feature is installed
-          before attempting to configure it.'
-    valid_schemas = ['anonymous', 'basic', 'clientCertificateMapping',
-                     'digest', 'iisClientCertificateMapping', 'windows']
-    validate do |value|
-      raise "#{name} should be a Hash" unless value.is_a? ::Hash
-      unless (value.keys & valid_schemas) == value.keys
-        raise('All schemas must specify any of the following: anonymous, basic, clientCertificateMapping, digest, iisClientCertificateMapping, or windows')
-      end
-    end
-  end
+  newproperty(:authenticationinfo, parent: PuppetX::PuppetLabs::IIS::Property::AuthenticationInfo)
 
   autorequire(:iis_application_pool) { self[:applicationpool] }
 

--- a/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb
@@ -1,0 +1,20 @@
+# The Puppet Extensions Module
+class PuppetX::PuppetLabs::IIS::Property::AuthenticationInfo < Puppet::Property
+  desc 'Enable and disable authentication schemas. Note: some schemas require
+        additional Windows features to be installed, for example windows
+        authentication. This type does not ensure a given feature is installed
+        before attempting to configure it.'
+  valid_schemas = ['anonymous', 'basic', 'clientCertificateMapping',
+                   'digest', 'iisClientCertificateMapping', 'windows']
+  def insync?(is)
+    should.reject { |k, v|
+      is[k] == v
+    }.empty?
+  end
+  validate do |value|
+    raise "#{name} should be a Hash" unless value.is_a? ::Hash
+    unless (value.keys & valid_schemas) == value.keys
+      raise('All schemas must specify any of the following: anonymous, basic, clientCertificateMapping, digest, iisClientCertificateMapping, or windows')
+    end
+  end
+end


### PR DESCRIPTION
Fixes: [MODULES-10362](https://tickets.puppetlabs.com/browse/MODULES-10362)

The handling of the `authenticationinfo` field is inconsistent.  Within the [`iis_site`](https://github.com/puppetlabs/puppetlabs-iis/blob/master/lib/puppet/type/iis_site.rb#L349-L362) resource, keys are checked for validity.

Within the [`iis_application`](https://github.com/puppetlabs/puppetlabs-iis/blob/master/lib/puppet/type/iis_application.rb#L81-L88) resource, the `insync?` function is redefined to ignore element ordering.

Both functionalities should be enforced in both places.

