### PR TITLE
(MAINT) Safeguard loading ruby-pwsh

### DIFF
--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -3,11 +3,19 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc 'IIS Application provider using the PowerShell WebAdministration module'
 
+  confine     feature: :pwshlib
   confine     feature: :iis_web_server
   confine     operatingsystem: [:windows]
-  defaultfor operatingsystem: :windows
+  defaultfor  operatingsystem: :windows
 
-  commands powershell: Pwsh::Manager.powershell_path
+  def self.powershell_path
+    require 'ruby-pwsh'
+    Pwsh::Manager.powershell_path
+  rescue
+    nil
+  end
+
+  commands powershell: powershell_path
 
   mk_resource_methods
 

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -3,11 +3,19 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc 'IIS Application Pool provider using the PowerShell WebAdministration module'
 
+  confine     feature: :pwshlib
   confine     feature: :iis_web_server
   confine     operatingsystem: [:windows]
   defaultfor operatingsystem: :windows
 
-  commands powershell: Pwsh::Manager.powershell_path
+  def self.powershell_path
+    require 'ruby-pwsh'
+    Pwsh::Manager.powershell_path
+  rescue
+    nil
+  end
+
+  commands powershell: powershell_path
 
   mk_resource_methods
 

--- a/lib/puppet/provider/iis_feature/default.rb
+++ b/lib/puppet/provider/iis_feature/default.rb
@@ -6,10 +6,18 @@ Puppet::Type.type(:iis_feature).provide(:default, parent: Puppet::Provider::IIS_
   require Pathname.new(__FILE__).dirname + '..' + '..' + '..' + 'puppet_x' + 'puppetlabs' + 'iis' + 'iis_features'
   include PuppetX::IIS::Features
 
+  confine    feature: :pwshlib
   confine    operatingsystem: [:windows]
   defaultfor operatingsystem: :windows
 
-  commands powershell: Pwsh::Manager.powershell_path
+  def self.powershell_path
+    require 'ruby-pwsh'
+    Pwsh::Manager.powershell_path
+  rescue
+    nil
+  end
+
+  commands powershell: powershell_path
 
   mk_resource_methods
 

--- a/lib/puppet/provider/iis_site/iisadministration.rb
+++ b/lib/puppet/provider/iis_site/iisadministration.rb
@@ -4,12 +4,20 @@ require 'ruby-pwsh'
 Puppet::Type.type(:iis_site).provide(:iisadministration) do
   desc 'IIS Provider using the PowerShell IISAdministration module'
 
+  confine    feature: :pwshlib
   confine    iis_version: ['10']
   confine    operatingsystem: [:windows]
   confine    kernelmajversion: 10.0
   defaultfor operatingsystem: :windows
 
-  commands powershell: Pwsh::Manager.powershell_path
+  def self.powershell_path
+    require 'ruby-pwsh'
+    Pwsh::Manager.powershell_path
+  rescue
+    nil
+  end
+
+  commands powershell: powershell_path
 
   mk_resource_methods
 

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -9,11 +9,19 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc 'IIS Provider using the PowerShell WebAdministration module'
 
+  confine     feature: :pwshlib
   confine     feature: :iis_web_server
   confine     operatingsystem: [:windows]
-  defaultfor operatingsystem: :windows
+  defaultfor  operatingsystem: :windows
 
-  commands powershell: Pwsh::Manager.powershell_path
+  def self.powershell_path
+    require 'ruby-pwsh'
+    Pwsh::Manager.powershell_path
+  rescue
+    nil
+  end
+
+  commands powershell: powershell_path
 
   mk_resource_methods
 

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -4,11 +4,19 @@ require File.join(File.dirname(__FILE__), '../../../puppet/provider/iis_powershe
 Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Puppet::Provider::IIS_PowerShell) do
   desc 'IIS Virtual Directory provider using the PowerShell WebAdministration module'
 
+  confine     feature: :pwshlib
   confine     feature: :iis_web_server
   confine     operatingsystem: [:windows]
-  defaultfor operatingsystem: :windows
+  defaultfor  operatingsystem: :windows
 
-  commands powershell: Pwsh::Manager.powershell_path
+  def self.powershell_path
+    require 'ruby-pwsh'
+    Pwsh::Manager.powershell_path
+  rescue
+    nil
+  end
+
+  commands powershell: powershell_path
 
   mk_resource_methods
 


### PR DESCRIPTION
This commit replaces the requires statement in the provider
with a confine to the pwshlib feature provided in the dependent
module to prevent exploding puppet runs on provider load.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
