### PR TITLE
(MAINT) Rename localized idempotent_apply to fix CI

### DIFF
--- a/spec/acceptance/iis_application_pool_spec.rb
+++ b/spec/acceptance/iis_application_pool_spec.rb
@@ -10,7 +10,7 @@ describe 'iis_application_pool', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app pool', manifest)
+      iis_idempotent_apply('create app pool', manifest)
 
       it 'resource iis_application_pool is present' do
         puppet_resource_should_show('ensure', 'present', resource('iis_application_pool', pool_name))
@@ -33,7 +33,7 @@ describe 'iis_application_pool', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app pool', manifest)
+      iis_idempotent_apply('create app pool', manifest)
 
       it 'has all properties correctly configured' do
         # Properties introduced in IIS 7.0 (Server 2008 - Kernel 6.1)
@@ -98,7 +98,7 @@ describe 'iis_application_pool', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app pool', manifest)
+      iis_idempotent_apply('create app pool', manifest)
 
       it 'has all properties correctly configured' do
         resource_data = resource('iis_application_pool', pool_name)
@@ -173,7 +173,7 @@ describe 'iis_application_pool', :suite_a do
       stop_app_pool(pool_name)
     end
 
-    idempotent_apply('start the app pool', manifest)
+    iis_idempotent_apply('start the app pool', manifest)
 
     it 'iis_application_pool is present and has the correct state' do
       resource_data = resource('iis_application_pool', pool_name)
@@ -202,7 +202,7 @@ describe 'iis_application_pool', :suite_a do
       create_app_pool(pool_name)
     end
 
-    idempotent_apply('remove the app pool', manifest)
+    iis_idempotent_apply('remove the app pool', manifest)
 
     it 'iis_application_pool is absent' do
       puppet_resource_should_show('ensure', 'absent', resource('iis_application_pool', pool_name))
@@ -224,7 +224,7 @@ describe 'iis_application_pool', :suite_a do
       stop_app_pool(pool_name)
     end
 
-    idempotent_apply('set memory limit', manifest)
+    iis_idempotent_apply('set memory limit', manifest)
 
     it 'has all properties correctly configured' do
       resource_data = resource('iis_application_pool', pool_name)
@@ -281,7 +281,7 @@ describe 'iis_application_pool', :suite_a do
       }
     HERE
 
-    idempotent_apply('create app pool', manifest)
+    iis_idempotent_apply('create app pool', manifest)
 
     it 'has all properties correctly configured' do
       resource_data = resource('iis_application_pool', pool_name)

--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -26,7 +26,7 @@ describe 'iis_application', :suite_a do
           physicalpath => 'C:\\inetpub\\basic',
         }
       HERE
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
 
       # include_context 'with a puppet resource run'# do
       it 'iis_application is absent' do
@@ -74,7 +74,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
 
       it 'iis_application is absent' do
         result = resource('iis_application', "#{site_name}\\#{app_name}")
@@ -109,7 +109,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
 
       it 'creates the correct application' do
         result = resource('iis_application', "#{site_name}\\subFolder/#{app_name}")
@@ -139,7 +139,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
 
       it 'creates the correct application' do
         result = resource('iis_application', "#{site_name}\\subFolder/#{app_name}")
@@ -171,7 +171,7 @@ describe 'iis_application', :suite_a do
           }
         HERE
 
-        idempotent_apply('create app', manifest)
+        iis_idempotent_apply('create app', manifest)
 
         after(:all) do
           remove_app(app_name)
@@ -197,7 +197,7 @@ describe 'iis_application', :suite_a do
           }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
 
       after(:all) do
         remove_app(app_name)
@@ -222,7 +222,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
 
       it 'creates the correct application' do
         result = resource('iis_application', "#{site_name}\\subFolder/sub2/#{app_name}")
@@ -277,7 +277,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
     end
 
     describe 'authenticationinfo' do
@@ -302,7 +302,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
       after(:all) do
         remove_app(app_name)
         remove_all_sites
@@ -329,7 +329,7 @@ describe 'iis_application', :suite_a do
         }
       HERE
 
-      idempotent_apply('create app', manifest)
+      iis_idempotent_apply('create app', manifest)
       after(:all) do
         remove_app(app_name)
         remove_all_sites
@@ -355,7 +355,7 @@ describe 'iis_application', :suite_a do
       }
     HERE
 
-    idempotent_apply('create app', manifest)
+    iis_idempotent_apply('create app', manifest)
 
     it 'iis_application is absent' do
       result = resource('iis_application', "#{site_name}\\#{app_name}")
@@ -404,7 +404,7 @@ describe 'iis_application', :suite_a do
       }
     HERE
 
-    idempotent_apply('create app', manifest)
+    iis_idempotent_apply('create app', manifest)
 
     it 'contains the first site with the same app name' do
       result = resource('iis_application', "#{site_name}\\#{app_name}")

--- a/spec/acceptance/iis_feature_spec.rb
+++ b/spec/acceptance/iis_feature_spec.rb
@@ -9,7 +9,7 @@ describe 'when managing features iis_features', :suite_a do
       }
     HERE
 
-    idempotent_apply('create iis feature', manifest)
+    iis_idempotent_apply('create iis feature', manifest)
 
     it 'iis_feature is present' do
       result = resource('iis_feature', feature)

--- a/spec/acceptance/iis_minimal_config_spec.rb
+++ b/spec/acceptance/iis_minimal_config_spec.rb
@@ -14,5 +14,5 @@ describe 'a minimal IIS config:', :suite_a do
     }
   EOF
 
-  idempotent_apply('create app', manifest)
+  iis_idempotent_apply('create app', manifest)
 end

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -21,7 +21,7 @@ describe 'iis_site', :suite_b do
         }
       HERE
 
-      idempotent_apply('create iis site', manifest)
+      iis_idempotent_apply('create iis site', manifest)
 
       it 'has all properties correctly configured' do
         resource_data = resource('iis_site', site_name)
@@ -149,7 +149,7 @@ describe 'iis_site', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis site', manifest)
+        iis_idempotent_apply('create iis site', manifest)
 
         it 'has all properties correctly configured' do
           resource_data = resource('iis_site', site_name)
@@ -187,7 +187,7 @@ describe 'iis_site', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis site', manifest)
+        iis_idempotent_apply('create iis site', manifest)
 
         it 'has all properties correctly configured' do
           resource_data = resource('iis_site', site_name)
@@ -228,7 +228,7 @@ describe 'iis_site', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis site', manifest)
+        iis_idempotent_apply('create iis site', manifest)
 
         after(:all) do
           remove_all_sites
@@ -251,7 +251,7 @@ describe 'iis_site', :suite_b do
           }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
 
           it 'has all properties correctly configured' do
             resource_data = resource('iis_site', site_name)
@@ -284,7 +284,7 @@ describe 'iis_site', :suite_b do
             }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
 
           it 'has all properties correctly configured' do
             resource_data = resource('iis_site', site_name)
@@ -313,7 +313,7 @@ describe 'iis_site', :suite_b do
           }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
 
           it 'iis site is absent' do
             resource_data = resource('iis_site', site_name)
@@ -387,7 +387,7 @@ describe 'iis_site', :suite_b do
             }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
 
           it 'has physicalpath configured' do
             puppet_resource_should_show('physicalpath', 'C:\\inetpub\\new', resource('iis_site', site_name))
@@ -413,7 +413,7 @@ describe 'iis_site', :suite_b do
             }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
           it 'has applicationpool configured' do
             puppet_resource_should_show('applicationpool', pool_name, resource('iis_site', site_name))
           end
@@ -462,7 +462,7 @@ describe 'iis_site', :suite_b do
             }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
           after(:all) do
             remove_all_sites
           end
@@ -492,7 +492,7 @@ describe 'iis_site', :suite_b do
             }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
 
           it 'has enabledprotocols configured' do
             puppet_resource_should_show('enabledprotocols', 'https', resource('iis_site', site_name))
@@ -528,7 +528,7 @@ describe 'iis_site', :suite_b do
             }
           HERE
 
-          idempotent_apply('create iis site', manifest)
+          iis_idempotent_apply('create iis site', manifest)
 
           it 'has logflags configured' do
             puppet_resource_should_show('logflags', ['ClientIP', 'Date', 'Method'], resource('iis_site', site_name))
@@ -583,7 +583,7 @@ describe 'iis_site', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis site', manifest)
+        iis_idempotent_apply('create iis site', manifest)
 
         it 'runs the first site on port 80' do
           first_site = resource('iis_site', site_name)
@@ -631,7 +631,7 @@ describe 'iis_site', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis site', manifest)
+        iis_idempotent_apply('create iis site', manifest)
 
         it 'resource iis_site is' do
           puppet_resource_should_show('ensure', 'stopped', resource('iis_site', site_name))
@@ -662,7 +662,7 @@ describe 'iis_site', :suite_b do
         }
       HERE
 
-      idempotent_apply('create iis site', manifest)
+      iis_idempotent_apply('create iis site', manifest)
 
       it 'runs the first site on port 80 with no host header' do
         first_site = resource('iis_site', site_name)

--- a/spec/acceptance/iis_virtual_directory_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_spec.rb
@@ -35,7 +35,7 @@ describe 'iis_virtual_directory', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis virtual dir', manifest)
+        iis_idempotent_apply('create iis virtual dir', manifest)
       end
 
       context 'when puppet resource is run' do
@@ -69,7 +69,7 @@ describe 'iis_virtual_directory', :suite_b do
           }
           HERE
 
-          idempotent_apply('create iis virtual dir', manifest)
+          iis_idempotent_apply('create iis virtual dir', manifest)
         end
 
         context 'when puppet resource is run' do
@@ -99,7 +99,7 @@ describe 'iis_virtual_directory', :suite_b do
         }
       HERE
 
-      idempotent_apply('create iis virtual dir', manifest)
+      iis_idempotent_apply('create iis virtual dir', manifest)
 
       it 'all parameters are configured' do
         resource_data = resource('iis_virtual_directory', virt_dir_name)
@@ -130,7 +130,7 @@ describe 'iis_virtual_directory', :suite_b do
           ensure       => 'absent'
         }
         HERE
-      idempotent_apply('remove iis virtual dir', manifest)
+      iis_idempotent_apply('remove iis virtual dir', manifest)
 
       it 'iis_virtual_directory to be absent' do
         puppet_resource_should_show('ensure', 'absent', resource('iis_virtual_directory', virt_dir_name))
@@ -163,7 +163,7 @@ describe 'iis_virtual_directory', :suite_b do
           physicalpath => 'c:\\inetpub\\deeper',
         }
         HERE
-        idempotent_apply('create iis virtual dir', manifest)
+        iis_idempotent_apply('create iis virtual dir', manifest)
 
         after(:all) do
           remove_vdir(virt_dir_name)

--- a/spec/acceptance/iis_virtual_directory_spec_test.rb
+++ b/spec/acceptance/iis_virtual_directory_spec_test.rb
@@ -49,7 +49,7 @@ describe 'iis_virtual_directory', :suite_b do
         }
       HERE
 
-      idempotent_apply('create iis virtual dir', manifest)
+      iis_idempotent_apply('create iis virtual dir', manifest)
 
       it 'iis_virtual_directory should be present' do
         puppet_resource_should_show('ensure', 'present', resource('iis_virtual_directory', virt_dir_name))
@@ -59,7 +59,7 @@ describe 'iis_virtual_directory', :suite_b do
         apply_manifest(manifest2, catch_changes: true)
       end
 
-      idempotent_apply('change physical path', manifest3)
+      iis_idempotent_apply('change physical path', manifest3)
 
       it 'physicalpath to be configured' do
         puppet_resource_should_show('physicalpath', 'c:\\foo2', resource('iis_virtual_directory', virt_dir_name))
@@ -88,7 +88,7 @@ describe 'iis_virtual_directory', :suite_b do
           }
         HERE
 
-        idempotent_apply('create iis virtual dir', manifest)
+        iis_idempotent_apply('create iis virtual dir', manifest)
 
         it 'all parameters are configured' do
           resource_data = resource('iis_virtual_directory', virt_dir_name)
@@ -120,7 +120,7 @@ describe 'iis_virtual_directory', :suite_b do
         }
       HERE
 
-      idempotent_apply('create iis virtual dir', manifest)
+      iis_idempotent_apply('create iis virtual dir', manifest)
 
       it 'iis_virtual_directory to be absent' do
         puppet_resource_should_show('ensure', 'absent', resource('iis_virtual_directory', virt_dir_name))
@@ -152,7 +152,7 @@ describe 'iis_virtual_directory', :suite_b do
         physicalpath => 'c:\\inetpub\\deeper',
       }
       HERE
-      idempotent_apply('create iis virtual dir', manifest)
+      iis_idempotent_apply('create iis virtual dir', manifest)
 
       after(:all) do
         remove_vdir(virt_dir_name)

--- a/spec/support/utilities/utility_helper.rb
+++ b/spec/support/utilities/utility_helper.rb
@@ -28,7 +28,7 @@ def create_selfsigned_cert(dnsname)
   result.stdout.chomp
 end
 
-def idempotent_apply(work_description, manifest)
+def iis_idempotent_apply(work_description, manifest)
   it "#{work_description} runs without errors" do
     apply_manifest(manifest, catch_failures: true)
   end


### PR DESCRIPTION
Prior to this commit the acceptance tests for this module referenced a local implementation of the `idempotent_apply` method, clobbering the same method made available via Litmus. At some point, the clobber stopped working, causing the test suite to fail immediately with argument errors.

This commit renames the local method to be `iis_idempotent_apply` and updates all references to `idempotent_apply` in the acceptance tests. It does *not* replace the localized implementation with the litmus one, as this will require a more extensive refactor of the test suite, to be done at a later time.

This change primarily exists to ensure CI is functional in the short term, which itself enables the refactor work.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
