### PR TITLE
(MODULES-10701) Make iis_application physicalpath optional.

### DIFF
--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -55,7 +55,6 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
       args << "-ApplicationPool #{@resource[:applicationpool].inspect}" if @resource[:applicationpool]
       inst_cmd = "ConvertTo-WebApplication #{args.join(' ')} -Force -ErrorAction Stop"
     else
-      raise 'Error creating application: physicalpath is required to create' unless @resource[:physicalpath]
       inst_cmd = self.class.ps_script_content('newapplication', @resource)
     end
     result = self.class.run(inst_cmd)

--- a/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
@@ -20,7 +20,10 @@ describe 'iis_application provider' do
         { title: 'foo\bar' }
       end
 
-      it { expect { iis_application_provider.create }.to raise_error(RuntimeError, %r{physicalpath}) }
+      before :each do
+        allow(Puppet::Provider::IIS_PowerShell).to receive(:run).with(%r{New-WebApplication}).and_return(exitcode: 0)
+      end
+      it { iis_application_provider.create }
     end
     context 'with nonexistent physicalpath' do
       let(:params) do


### PR DESCRIPTION
`New-WebApplication -PhysicalPath` is not a required parameter.
Allowing `iis_application` without setting `physicalpath` allows other systems to change `physicalpath` without puppet undoing the changes.
(e.g. We use this when deploying web apps via Octopus Deploy).
