### PR TITLE
(MODULES-10702) Make certificatestorename case insensitive.

### DIFF
--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -160,6 +160,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
         # of "http" will raise an error."
         binding.delete('certificatehash') unless binding['protocol'] == 'https'
         binding.delete('certificatestorename') unless binding['protocol'] == 'https'
+        binding['certificatestorename'] = binding['certificatestorename'].upcase unless binding['certificatestorename'].nil?
       end
       site['limits'] = {} if site['limits'].nil?
       site['authenticationinfo'] = {} if site['authenticationinfo'].nil?

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -172,6 +172,9 @@ Puppet::Type.newtype(:iis_site) do
       if !value.nil? && value['certificatehash']
         value['certificatehash'] = value['certificatehash'].upcase
       end
+      if !value.nil? && value['certificatestorename']
+        value['certificatestorename'] = value['certificatestorename'].upcase
+      end
       value
     end
 

--- a/spec/acceptance/iis_site_spec.rb
+++ b/spec/acceptance/iis_site_spec.rb
@@ -70,7 +70,7 @@ describe 'iis_site', :suite_b do
                 {
                   'bindinginformation'   => '*:443:www.puppet.local',
                   'certificatehash'      => '#{certificate_hash}',
-                  'certificatestorename' => 'MY',
+                  'certificatestorename' => 'My',
                   'protocol'             => 'https',
                   'sslflags'             => 1,
                 },


### PR DESCRIPTION
This makes sure that puppet run are idempotent on servers on which the Powershell `WebAdministration` module shows inconsistent casing for the certificate store names.

```
ls IIS:\SslBindings\ | ft -AutoSize

IP Address  Port    Host Name             Store  Sites
----------  ----    ---------             -----  -----
            443     somewebsite.com       My    somewebsite.com
            443     someotherwebsite.com  MY    someotherwebsite.com
0.0.0.0     8172                          MY
```