### PR TITLE
Make iis application physicalpath optional

### DIFF
--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -55,7 +55,6 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
       args << "-ApplicationPool #{@resource[:applicationpool].inspect}" if @resource[:applicationpool]
       inst_cmd = "ConvertTo-WebApplication #{args.join(' ')} -Force -ErrorAction Stop"
     else
-      raise 'Error creating application: physicalpath is required to create' unless @resource[:physicalpath]
       inst_cmd = self.class.ps_script_content('newapplication', @resource)
     end
     result = self.class.run(inst_cmd)

--- a/spec/acceptance/iis_application_spec.rb
+++ b/spec/acceptance/iis_application_spec.rb
@@ -363,6 +363,36 @@ describe 'iis_application', :suite_a do
     end
     after(:all) do
       remove_app(app_name)
+      remove_all_sites
+    end
+  end
+
+  context 'physicalpath is not set' do
+    site_name = SecureRandom.hex(10).to_s
+    app_name = SecureRandom.hex(10).to_s
+    before(:all) do
+      create_site(site_name, true)
+      create_path('C:\inetpub\basic')
+      create_virtual_directory(site_name, app_name, 'C:\inetpub\basic')
+      create_app(site_name, app_name)
+    end
+
+    manifest = <<-HERE
+        iis_site { '#{site_name}':
+          ensure          => 'started',
+          physicalpath    => 'C:\\inetpub\\basic',
+          applicationpool => 'DefaultAppPool',
+        }
+        iis_application { '#{app_name}':
+          ensure       => 'present',
+          sitename     => '#{site_name}',
+        }
+      HERE
+    iis_idempotent_apply('create app', manifest)
+
+    after(:all) do
+      remove_app(app_name)
+      remove_all_sites
     end
   end
 

--- a/spec/support/utilities/iis_application.rb
+++ b/spec/support/utilities/iis_application.rb
@@ -3,8 +3,9 @@ def has_app(app_name)
   !(run_shell(command).stdout =~ %r{Started}i).nil?
 end
 
-def create_app(site_name, app_name, directory)
-  command = format_powershell_iis_command("New-WebApplication -Site #{site_name} -Name #{app_name} -PhysicalPath #{directory} -Force -ErrorAction Stop")
+def create_app(site_name, app_name, directory = nil)
+  physicalpath_dash = directory ? "-PhysicalPath #{directory}" : ''
+  command = format_powershell_iis_command("New-WebApplication -Site #{site_name} -Name #{app_name} #{physicalpath_dash} -Force -ErrorAction Stop")
   run_shell(command) unless has_app(app_name)
 end
 

--- a/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
@@ -20,7 +20,10 @@ describe 'iis_application provider' do
         { title: 'foo\bar' }
       end
 
-      it { expect { iis_application_provider.create }.to raise_error(RuntimeError, %r{physicalpath}) }
+      before :each do
+        allow(Puppet::Provider::IIS_PowerShell).to receive(:run).with(%r{New-WebApplication}).and_return(exitcode: 0)
+      end
+      it { iis_application_provider.create }
     end
     context 'with nonexistent physicalpath' do
       let(:params) do


### PR DESCRIPTION
Opened this PR to add acceptance test for https://github.com/puppetlabs/puppetlabs-iis/pull/279:
> `New-WebApplication -PhysicalPath` is not a required parameter.
Allowing `iis_application` without setting `physicalpath` allows other systems to change `physicalpath` without puppet undoing the changes.

Closes: #279 