### PR TITLE
pdksync - (maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,11 +17,15 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
+        "2008",
         "2008 R2",
         "2012",
         "2012 R2",
         "2016",
-        "2019"
+        "2019",
+        "7",
+        "8",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
