### PR TITLE
(MODULES-10988) fix require_relative being not relative enough

### DIFF
--- a/lib/puppet/feature/iis_web_server.rb
+++ b/lib/puppet/feature/iis_web_server.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'puppet/util/feature'
-require_relative '../../../lib/puppet_x/puppetlabs/iis/iis_version'
+require_relative '../../puppet_x/puppetlabs/iis/iis_version'
 
 Puppet.features.add(:iis_web_server) do
   PuppetX::PuppetLabs::IIS::IISVersion.supported_version_installed?


### PR DESCRIPTION
In some cases running this outside the default puppet agent config this
can cause issues if the libdir does not end in `lib`.

This fix does away with the extraneous level of relativity and thus avoids
the problem. This is the only place in the module where this pattern was
used.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/main/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MAIN branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
