### PR TITLE
Using pdk 2.1.0.0 tagged version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
       - name: "PDK Build"
-        uses: docker://puppet/pdk:nightly
+        uses: docker://puppet/pdk:2.1.0.0
         with:
           args: 'build'
       - name: "Push to Forge"
-        uses: docker://puppet/pdk:nightly
+        uses: docker://puppet/pdk:2.1.0.0
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'


### PR DESCRIPTION
This change will be overridden on the next pdksync, but that is fine as I have a PR up include this change. Just speeding things up to get this module released today.

Change is here: https://github.com/puppetlabs/pdk-templates/pull/430