### PR TITLE
(MODULES-9656) - Enable using 0 for application pool settings

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -484,16 +484,22 @@ Specifies the amount of virtual memory (in kilobytes) that a worker
 process can use before the worker process is recycled. The maximum
 value supported for this property is 4,294,967 KB.
 
+A value of 0 sets this to unlimited.
+
 ##### `restart_private_memory_limit`
 
 Specifies the amount of private memory (in kilobytes) that a worker
 process can use before the worker process recycles. The maximum value
 supported for this property is 4,294,967 KB.
 
+A value of 0 sets this to unlimited.
+
 ##### `restart_requests_limit`
 
 Specifies that the worker process should be recycled after it
 processes a specific number of requests.
+
+A value of 0 sets this to unlimited.
 
 ##### `restart_schedule`
 

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -5,6 +5,7 @@ require_relative '../../puppet_x/puppetlabs/iis/property/name'
 require_relative '../../puppet_x/puppetlabs/iis/property/string'
 require_relative '../../puppet_x/puppetlabs/iis/property/positive_integer'
 require_relative '../../puppet_x/puppetlabs/iis/property/timeformat'
+require_relative '../../puppet_x/puppetlabs/iis/property/whole_number'
 
 Puppet::Type.newtype(:iis_application_pool) do
   @doc = 'Allows creation of a new IIS Application Pool and configuration of application pool parameters.'
@@ -146,7 +147,7 @@ Puppet::Type.newtype(:iis_application_pool) do
     newvalues(:NoAction, :KillW3wp, :Throttle, :ThrottleUnderLoad)
   end
 
-  newproperty(:cpu_limit, parent: PuppetX::PuppetLabs::IIS::Property::PositiveInteger) do
+  newproperty(:cpu_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Configures the maximum percentage of CPU time (in 1/1000ths of one
           percent) that the worker processes in an application pool are
           allowed to consume over a period of time as indicated by the
@@ -297,7 +298,7 @@ Puppet::Type.newtype(:iis_application_pool) do
     end
   end
 
-  newproperty(:max_processes, parent: PuppetX::PuppetLabs::IIS::Property::PositiveInteger) do
+  newproperty(:max_processes, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Indicates the maximum number of worker processes that would be used
           for the application pool.
 
@@ -488,19 +489,19 @@ Puppet::Type.newtype(:iis_application_pool) do
           'Memory', and 'PrivateMemory'; for IIS 10 and later are all values."
   end
 
-  newproperty(:restart_memory_limit, parent: PuppetX::PuppetLabs::IIS::Property::PositiveInteger) do
+  newproperty(:restart_memory_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Specifies the amount of virtual memory (in kilobytes) that a worker
           process can use before the worker process is recycled. The maximum
           value supported for this property is 4,294,967 KB."
   end
 
-  newproperty(:restart_private_memory_limit, parent: PuppetX::PuppetLabs::IIS::Property::PositiveInteger) do
+  newproperty(:restart_private_memory_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Specifies the amount of private memory (in kilobytes) that a worker
           process can use before the worker process recycles. The maximum value
           supported for this property is 4,294,967 KB."
   end
 
-  newproperty(:restart_requests_limit, parent: PuppetX::PuppetLabs::IIS::Property::PositiveInteger) do
+  newproperty(:restart_requests_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Specifies that the worker process should be recycled after it
           processes a specific number of requests."
   end

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -492,18 +492,24 @@ Puppet::Type.newtype(:iis_application_pool) do
   newproperty(:restart_memory_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Specifies the amount of virtual memory (in kilobytes) that a worker
           process can use before the worker process is recycled. The maximum
-          value supported for this property is 4,294,967 KB."
+          value supported for this property is 4,294,967 KB.
+
+          A value of 0 sets this to unlimited."
   end
 
   newproperty(:restart_private_memory_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Specifies the amount of private memory (in kilobytes) that a worker
           process can use before the worker process recycles. The maximum value
-          supported for this property is 4,294,967 KB."
+          supported for this property is 4,294,967 KB.
+
+          A value of 0 sets this to unlimited."
   end
 
   newproperty(:restart_requests_limit, parent: PuppetX::PuppetLabs::IIS::Property::WholeNumber) do
     desc "Specifies that the worker process should be recycled after it
-          processes a specific number of requests."
+          processes a specific number of requests.
+
+          A value of 0 sets this to unlimited."
   end
 
   newproperty(:restart_time_limit, parent: PuppetX::PuppetLabs::IIS::Property::TimeFormat) do

--- a/lib/puppet_x/puppetlabs/iis/property/whole_number.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/whole_number.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# The Puppet Extensions Module
+module PuppetX::PuppetLabs
+  # IIS
+  module IIS::Property
+    # WholeNumber Property
+    class WholeNumber < Puppet::Property
+      def insync?(is)
+        is.to_i == should.to_i
+      end
+      validate do |value|
+        raise "#{name} should be an Integer" unless value.to_i.to_s == value.to_s
+        raise "#{name} should be 0 or greater" unless value.to_i >= 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently is it not possible to set the following to 0. 
- cpu_limit
- max_processes
- restart_memory_limit
- restart_private_memory_limit
- restart_requests_limit

This PR adds a new property called whole number. A whole number can be any integer including 0 and applies it to the above.