### PR TITLE
Correct error handling in require ruby-pwsh

### DIFF
--- a/lib/puppet/provider/iis_application/webadministration.rb
+++ b/lib/puppet/provider/iis_application/webadministration.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:iis_application).provide(:webadministration, parent: Puppet::
   def self.powershell_path
     require 'ruby-pwsh'
     Pwsh::Manager.powershell_path
-  rescue
+  rescue LoadError
     nil
   end
 

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
   def self.powershell_path
     require 'ruby-pwsh'
     Pwsh::Manager.powershell_path
-  rescue
+  rescue LoadError
     nil
   end
 

--- a/lib/puppet/provider/iis_feature/default.rb
+++ b/lib/puppet/provider/iis_feature/default.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:iis_feature).provide(:default, parent: Puppet::Provider::IIS_
   def self.powershell_path
     require 'ruby-pwsh'
     Pwsh::Manager.powershell_path
-  rescue
+  rescue LoadError
     nil
   end
 

--- a/lib/puppet/provider/iis_site/iisadministration.rb
+++ b/lib/puppet/provider/iis_site/iisadministration.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'pathname'
-require 'ruby-pwsh'
 
 Puppet::Type.type(:iis_site).provide(:iisadministration) do
   desc 'IIS Provider using the PowerShell IISAdministration module'
@@ -15,7 +14,7 @@ Puppet::Type.type(:iis_site).provide(:iisadministration) do
   def self.powershell_path
     require 'ruby-pwsh'
     Pwsh::Manager.powershell_path
-  rescue
+  rescue LoadError
     nil
   end
 

--- a/lib/puppet/provider/iis_site/webadministration.rb
+++ b/lib/puppet/provider/iis_site/webadministration.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:iis_site).provide(:webadministration, parent: Puppet::Provide
   def self.powershell_path
     require 'ruby-pwsh'
     Pwsh::Manager.powershell_path
-  rescue
+  rescue LoadError
     nil
   end
 

--- a/lib/puppet/provider/iis_virtual_directory/webadministration.rb
+++ b/lib/puppet/provider/iis_virtual_directory/webadministration.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:iis_virtual_directory).provide(:webadministration, parent: Pu
   def self.powershell_path
     require 'ruby-pwsh'
     Pwsh::Manager.powershell_path
-  rescue
+  rescue LoadError
     nil
   end
 


### PR DESCRIPTION
The error handling around the require for 'ruby-pwsh'
tries to rescue with nil, but does not pass an argument
to rescue which by default will rescue only StandardError.

In this case it should rescue the LoadError which is not
a StandardError:

  LoadError.is_a? StandardError => false
