### PR TITLE
(MODULES-11188) Existing apps with / in path break

### DIFF
--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -12,7 +12,7 @@ Get-WebApplication | % {
     name               = $name
     site               = $site
     applicationpool    = [string]$_.ApplicationPool
-    physicalpath       = [string]$_.PhysicalPath
+    physicalpath       = [string]$_.PhysicalPath.TrimEnd("/")
     sslflags           = $sslFlags
     authenticationinfo = New-Object -TypeName PSObject -Property @{
       anonymous                   = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/anonymousAuthentication").enabled


### PR DESCRIPTION
# Context

The `physicalpath` in the `iis_site` is causing issues with existing IIS applications that have a forward slash in them.  This causes a parsing error which in turn will result in a failed run.

# What has change?

This commit adds TrimEnd() to the PhysicalPath property returned by Get-WebApplication. This will prevent parsing errors when existing apps have been configured with a trailing /.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/main/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MAIN branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
