### PR TITLE
(MODULES-11188) Fix physicalPath on apps and sites

### DIFF
--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -8,10 +8,10 @@ Get-WebSite | % {
   }
 
   $SiteEntityPath = "IIS:\\Sites\${name}"
-  $SitePhysicalPath = Get-ItemProperty -Path $SiteEntityPath -Name PhysicalPath
+  $SiteEntityPhysicalPath = Get-ItemProperty -Path $SiteEntityPath -Name physicalPath
 
-  if ($SitePhysicalPath.physicalpath.EndsWith('/')){
-    $null = Set-ItemProperty -Path $SiteEntityPath -Name PhysicalPath -Value $SitePhysicalPath.physicalpath.TrimEnd('/') -Force
+  if ($SiteEntityPhysicalPath.EndsWith('/')){
+    $null = Set-ItemProperty -Path $SiteEntityPath -Name PhysicalPath -Value $SiteEntityPhysicalPath.TrimEnd('/') -Force
   }
   
   $authenticationTypes = @(

--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -4,11 +4,11 @@ Get-WebApplication | % {
   $name = [string]$pattern.replace($_.Path,'',1)
   $site = [string]$_.ItemXPath.split("'")[1]
 
-  $SiteEntityPath = "IIS:\\Sites\${site}"
-  $SitePhysicalPath = Get-ItemProperty -Path $SiteEntityPath -Name PhysicalPath
+  $AppEntityPath = "IIS:\\Sites\${site}\${name}"
+  $AppEntityPhysicalPath = Get-ItemProperty -Path $AppEntityPath -Name physicalPath
 
-  if ($SitePhysicalPath.physicalpath.EndsWith('/')){
-    $null = Set-ItemProperty -Path $SiteEntityPath -Name PhysicalPath -Value $SitePhysicalPath.physicalpath.TrimEnd('/') -Force
+  if ($AppEntityPhysicalPath.EndsWith('/')){
+    $null = Set-ItemProperty -Path $AppEntityPath -Name physicalPath -Value $AppEntityPhysicalPath.TrimEnd('/') -Force
   }
 
   $sslFlags = @()


### PR DESCRIPTION
# Context

Prior to this PR it looks like we'd chosen the incorrect property to pull back from the iis config. It turns out that `PhysicalPath` != `physicalPath` and the former was behaving differently between the app and site resources.

# What has changed?

This PR standardises on physicalPath which returns the correct value for both app and site resources. For clarity, physicalPath returns a string which we can directly manipulate if required.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-iis/blob/main/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=15066&summary=%5BIIS%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MAIN branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
