### PR TITLE
(MAINT) Drop support for Windows Server 2008 R2.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppetlabs-iis",
   "version": "8.1.0",
   "author": "puppetlabs",
-  "summary": "Manage IIS for Windows Server 2008R2, 2012, 2012R2 and 2016. Maintain application sites, pools, installation, and many other IIS settings.",
+  "summary": "Manage IIS for Windows Server 2012, 2012R2 and 2016. Maintain application sites, pools, installation, and many other IIS settings.",
   "license": "Apache-2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-iis",
   "project_page": "https://github.com/puppetlabs/puppetlabs-iis",
@@ -17,7 +17,6 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
- Support was removed for Windows Server 2008 R2.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html
