### PR TITLE
(CONT-6) Hardening codebase - Dropping Powershell 2 Support

### DIFF
--- a/lib/puppet/provider/iis_feature/default.rb
+++ b/lib/puppet/provider/iis_feature/default.rb
@@ -35,11 +35,11 @@ Puppet::Type.type(:iis_feature).provide(:default, parent: Puppet::Provider::IIS_
     end
 
     cmd = []
-    cmd << "Import-Module ServerManager; Add-WindowsFeature -Name #{resource[:name]}" if self.class.is_windows2008 == true
-    cmd << "Install-WindowsFeature -Name #{resource[:name]} " if self.class.is_windows2008 == false
+    cmd << "Import-Module ServerManager; Add-WindowsFeature -Name '#{resource[:name]}'" if self.class.is_windows2008 == true
+    cmd << "Install-WindowsFeature -Name '#{resource[:name]}' " if self.class.is_windows2008 == false
     cmd << '-IncludeAllSubFeature ' if @resource[:include_all_subfeatures] == true
     cmd << '-Restart ' if @resource[:restart] == true
-    cmd << "-Source #{resource['source']} " if @resource[:source]
+    cmd << "-Source '#{resource['source']}' " if @resource[:source]
     cmd << '-IncludeManagementTools' if @resource[:include_management_tools] == true && self.class.is_windows2008 == false
 
     Puppet.debug "Powershell create command is '#{cmd}'"
@@ -55,8 +55,8 @@ Puppet::Type.type(:iis_feature).provide(:default, parent: Puppet::Provider::IIS_
     raise Puppet::Error, "iis_feature can only be used to install IIS features. '#{resource[:name]}' is not an IIS feature" unless PuppetX::IIS::Features.iis_feature?(resource[:name])
 
     cmd = []
-    cmd << "Import-Module ServerManager; Remove-WindowsFeature -Name #{resource[:name]}" if self.class.is_windows2008 == true
-    cmd << "Uninstall-WindowsFeature #{resource[:name]}" if self.class.is_windows2008 == false
+    cmd << "Import-Module ServerManager; Remove-WindowsFeature -Name '#{resource[:name]}'" if self.class.is_windows2008 == true
+    cmd << "Uninstall-WindowsFeature '#{resource[:name]}'" if self.class.is_windows2008 == false
     cmd << ' -Restart' if @resource[:restart] == true
 
     Puppet.debug "Powershell destroy command is '#{cmd}'"

--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -39,17 +39,6 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
   def self.run(command, _check = false)
     Puppet.debug("COMMAND: #{command}")
 
-    if ps_major_version == 2
-      # - PowerShell 2.0 does not support autoload of modules therefore we must explicitly add the WebAdministration module
-      # - Must change the current location to the be the IIS: provider
-      # - Add the ConvertTo-JSON command support
-      command = "Import-Module WebAdministration -ErrorAction Stop\n" \
-                "cd iis:\n" +
-                ps_script_content('json_1.7', @resource) + "\n" \
-                "$ConfirmPreference = 'high'" + "\n" +
-                command
-    end
-
     result = ps_manager.execute(command)
     stderr = result[:stderr]
 

--- a/spec/unit/puppet/provider/iis_powershell_spec.rb
+++ b/spec/unit/puppet/provider/iis_powershell_spec.rb
@@ -22,37 +22,6 @@ describe 'test' do
       allow(ps_manager).to receive(:execute).and_return(execute_response)
     end
 
-    describe 'When on PowerShell 2.0' do
-      before(:each) do
-        allow(Puppet::Provider::IIS_PowerShell).to receive(:ps_major_version).and_return(2)
-      end
-
-      it 'appends Importing the WebAdministration module' do
-        expect(ps_manager).to receive(:execute).with(%r{Import-Module WebAdministration}).and_return(execute_response)
-        iis_powershell_type.run(command)
-      end
-
-      it 'appends changing the working directory to IIS' do
-        expect(ps_manager).to receive(:execute).with(%r{cd iis:}).and_return(execute_response)
-        iis_powershell_type.run(command)
-      end
-
-      it 'appends a JSON converter' do
-        expect(ps_manager).to receive(:execute).with(%r{ConvertTo\-JSON}).and_return(execute_response)
-        iis_powershell_type.run(command)
-      end
-
-      it 'sets Confirmation Preference' do
-        expect(ps_manager).to receive(:execute).with(%r{\$ConfirmPreference = 'high'}).and_return(execute_response)
-        iis_powershell_type.run(command)
-      end
-
-      it 'appends the original command at the end' do
-        expect(ps_manager).to receive(:execute).with(%r{#{command}$}).and_return(execute_response)
-        iis_powershell_type.run(command)
-      end
-    end
-
     [3, 4, 5, 6].each do |testcase|
       describe "When on PowerShell #{testcase}.0" do
         before(:each) do


### PR DESCRIPTION
This PR aims to implement some changes that ensure no malformed commands are passed through to the system, as well as removing some no longer needed code.

Beware, this PR removes compatibility for the outdated PowerShell 2.0.