### PR TITLE
(CONT-782) - Update Naming/MethodParameterName to allow 'is'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,3 +84,5 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
+Naming/MethodParameterName:
+  AllowedNames: 'is'

--- a/lib/puppet/type/iis_site.rb
+++ b/lib/puppet/type/iis_site.rb
@@ -34,10 +34,10 @@ Puppet::Type.newtype(:iis_site) do
       provider.destroy
     end
 
-    def insync?(service)
-      service.to_s == should.to_s ||
-        (service.to_s == 'started' && should.to_s == 'present') ||
-        (service.to_s == 'stopped' && should.to_s == 'present')
+    def insync?(is)
+      is.to_s == should.to_s ||
+        (is.to_s == 'started' && should.to_s == 'present') ||
+        (is.to_s == 'stopped' && should.to_s == 'present')
     end
 
     aliasvalue(:false, :stopped)
@@ -165,8 +165,8 @@ Puppet::Type.newtype(:iis_site) do
       @should = PuppetX::PuppetLabs::IIS::Bindings.sort_bindings(@should)
     end
 
-    def insync?(service)
-      PuppetX::PuppetLabs::IIS::Bindings.sort_bindings(service) == should
+    def insync?(is)
+      PuppetX::PuppetLabs::IIS::Bindings.sort_bindings(is) == should
     end
   end
 
@@ -296,8 +296,8 @@ Puppet::Type.newtype(:iis_site) do
     end
   end
 
-  def insync?(service)
-    service.sort == should.sort
+  def insync?(is)
+    is.sort == should.sort
   end
 
   newproperty(:limits) do
@@ -312,9 +312,9 @@ Puppet::Type.newtype(:iis_site) do
         raise("Invalid value '#{limit} for #{key}'. Cannot be less than 1 or greater than 4294967295") if key != 'connectiontimeout' && (limit < 1 || limit > 4_294_967_295)
       end
     end
-    def insync?(service)
+    def insync?(is)
       should.reject { |k, v|
-        service[k] == v
+        is[k] == v
       }.empty?
     end
   end

--- a/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb
@@ -8,9 +8,9 @@ class PuppetX::PuppetLabs::IIS::Property::AuthenticationInfo < Puppet::Property
         before attempting to configure it.'
   valid_schemas = ['anonymous', 'basic', 'clientCertificateMapping',
                    'digest', 'iisClientCertificateMapping', 'windows']
-  def insync?(service)
+  def insync?(is)
     should.reject { |k, v|
-      service[k] == v
+      is[k] == v
     }.empty?
   end
   validate do |value|

--- a/lib/puppet_x/puppetlabs/iis/property/positive_integer.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/positive_integer.rb
@@ -10,8 +10,8 @@ module PuppetX
       module Property
         # PositiveInteger Property
         class PositiveInteger < Puppet::Property
-          def insync?(service)
-            service.to_i == should.to_i
+          def insync?(is)
+            is.to_i == should.to_i
           end
           validate do |value|
             raise "#{name} should be an Integer" unless value.to_i.to_s == value.to_s

--- a/lib/puppet_x/puppetlabs/iis/property/whole_number.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/whole_number.rb
@@ -6,8 +6,8 @@ module PuppetX::PuppetLabs
   module IIS::Property
     # WholeNumber Property
     class WholeNumber < Puppet::Property
-      def insync?(service)
-        service.to_i == should.to_i
+      def insync?(is)
+        is.to_i == should.to_i
       end
       validate do |value|
         raise "#{name} should be an Integer" unless value.to_i.to_s == value.to_s


### PR DESCRIPTION
Adds `is` to list of allowed variable names by `Naming/MethodParameterName` and reverts changes made when fixing this violation.