### PR TITLE
pdksync - (CAT-1366) - Fix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-iis",
   "project_page": "https://github.com/puppetlabs/puppetlabs-iis",
-  "issues_url": "https://tickets.puppet.com/browse/MODULES",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-iis/issues",
   "dependencies": [
     {
       "name": "puppetlabs/pwshlib",


### PR DESCRIPTION
(CAT-1366) - Fix issue url from old jira to github
pdk version: `2.7.0` 
