### PR TITLE
[CAT-1382] : Fixing CI failure due to rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -98,13 +98,6 @@ RSpec/ExampleLength:
   Max: 37
 
 # Offense count: 1
-# Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
-# Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
-  Exclude:
-    - 'spec/acceptance/iis_virtual_directory_spec_test.rb'
-
-# Offense count: 1
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:
@@ -140,6 +133,7 @@ RSpec/NoExpectationExample:
     - 'spec/unit/puppet/provider/iis_virtual_directory/webadministration_spec.rb'
     - 'spec/unit/puppet/type/iis_site_spec.rb'
     - 'spec/unit/puppet/type/iis_virtual_directory_spec.rb'
+    - 'spec/acceptance/iis_virtual_directory_test_spec.rb'
 
 # Offense count: 4
 RSpec/StubbedMock:

--- a/spec/acceptance/iis_virtual_directory_test_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_test_spec.rb
@@ -115,6 +115,7 @@ describe 'iis_virtual_directory', :suite_b do
 
       manifest = <<-HERE
         iis_virtual_directory { '#{virt_dir_name}':
+          sitename     => '#{site_name}',
           ensure       => 'absent'
         }
       HERE

--- a/spec/acceptance/iis_virtual_directory_test_spec.rb
+++ b/spec/acceptance/iis_virtual_directory_test_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper_acceptance'
 
 describe 'iis_virtual_directory', :suite_b do
   site_name = SecureRandom.hex(10)
-  before(:all) do
+  before(:context) do
     # Remove 'Default Web Site' to start from a clean slate
     remove_all_sites
     create_site(site_name, true)
   end
 
-  after(:all) do
+  after(:context) do
     remove_all_sites
   end
 
@@ -55,7 +55,7 @@ describe 'iis_virtual_directory', :suite_b do
       iis_idempotent_apply('create iis virtual dir', manifest)
 
       after(:all) do
-        remove_vdir(virt_dir_name)
+        remove_vdir(virt_dir_name, site_name)
       end
 
       it 'iis_virtual_directory should be present' do
@@ -74,47 +74,43 @@ describe 'iis_virtual_directory', :suite_b do
     end
 
     context 'with a password wrapped in Sensitive()' do
-      if installed_puppet_version.to_i < 5
-        skip 'is skipped due to version being lower than puppet 5'
-      else
-        virt_dir_name = SecureRandom.hex(10).to_s
-        manifest = <<-HERE
-          file{ 'c:/foo':
-            ensure => 'directory'
-          }->
-          iis_virtual_directory { '#{virt_dir_name}':
-            ensure       => 'present',
-            sitename     => '#{site_name}',
-            physicalpath => 'c:\\foo',
-            user_name    => 'user',
-            password     => Sensitive('#@\\'454sdf'),
-          }
-        HERE
+      virt_dir_name = SecureRandom.hex(10).to_s
+      manifest = <<-HERE
+        file{ 'c:/foo':
+          ensure => 'directory'
+        }->
+        iis_virtual_directory { '#{virt_dir_name}':
+          ensure       => 'present',
+          sitename     => '#{site_name}',
+          physicalpath => 'c:\\foo',
+          user_name    => 'user',
+          password     => Sensitive('#@\\'454sdf'),
+        }
+      HERE
 
-        iis_idempotent_apply('create iis virtual dir', manifest)
+      iis_idempotent_apply('create iis virtual dir', manifest)
 
-        it 'all parameters are configured' do
-          resource_data = resource('iis_virtual_directory', virt_dir_name)
-          [
-            'ensure', 'present',
-            'user_name', 'user',
-            'password', '#@\\\'454sdf'
-          ].each_slice(2) do |key, value|
-            puppet_resource_should_show(key, value, resource_data)
-          end
+      it 'all parameters are configured' do
+        resource_data = resource('iis_virtual_directory', virt_dir_name)
+        [
+          'ensure', 'present',
+          'user_name', 'user',
+          'password', '#@\\\'454sdf'
+        ].each_slice(2) do |key, value|
+          puppet_resource_should_show(key, value, resource_data)
         end
+      end
 
-        it 'remove virt dir name' do
-          remove_vdir(virt_dir_name)
-        end
+      it 'remove virt dir name' do
+        remove_vdir(virt_dir_name, site_name)
       end
     end
 
-    context 'can remove virtual directory' do
+    context 'when virtual directory is removed' do
       virt_dir_name = SecureRandom.hex(10).to_s
       before(:all) do
         create_path('c:/foo')
-        create_vdir(virt_dir_name, 'foo', 'c:/foo')
+        create_vdir(virt_dir_name, site_name, 'c:/foo')
       end
 
       manifest = <<-HERE
@@ -123,7 +119,7 @@ describe 'iis_virtual_directory', :suite_b do
         }
       HERE
 
-      iis_idempotent_apply('create iis virtual dir', manifest)
+      iis_idempotent_apply('remove iis virtual dir', manifest)
 
       after(:all) do
         remove_vdir(virt_dir_name)
@@ -134,37 +130,8 @@ describe 'iis_virtual_directory', :suite_b do
       end
     end
 
-    context 'name allows slashes' do
-      virt_dir_name = SecureRandom.hex(10).to_s
-      before(:all) do
-        create_path('c:\inetpub\test_site')
-        create_path('c:\inetpub\test_vdir')
-        create_path('c:\inetpub\deeper')
-        create_site(site_name, true)
-      end
-
-      manifest = <<-HERE
-      iis_virtual_directory{ "test_vdir":
-        ensure       => 'present',
-        sitename     => "#{site_name}",
-        physicalpath => 'c:\\inetpub\\test_vdir',
-      }->
-      iis_virtual_directory { 'test_vdir\deeper':
-        name         => 'test_vdir\deeper',
-        ensure       => 'present',
-        sitename     => '#{site_name}',
-        physicalpath => 'c:\\inetpub\\deeper',
-      }
-      HERE
-      iis_idempotent_apply('create iis virtual dir', manifest)
-
-      after(:all) do
-        remove_vdir(virt_dir_name)
-      end
-    end
-
     context 'with invalid' do
-      context 'physicalpath parameter defined' do
+      context 'when physicalpath parameter is defined' do
         virt_dir_name = SecureRandom.hex(10).to_s
         manifest = <<-HERE
           iis_virtual_directory { '#{virt_dir_name}':
@@ -184,7 +151,7 @@ describe 'iis_virtual_directory', :suite_b do
         end
       end
 
-      context 'physicalpath parameter not defined' do
+      context 'when physicalpath parameter is not defined' do
         virt_dir_name = SecureRandom.hex(10).to_s
         manifest = <<-HERE
           iis_virtual_directory { '#{virt_dir_name}':


### PR DESCRIPTION
## Summary
Fixing CI failure due to rubocop

## Additional Context
- [x] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Split RSpec/FilePath into RSpec/SpecFilePathSuffix and RSpec/SpecFilePathFormat. RSpec/FilePath cop is enabled by default, the two new cops are pending and need to be enabled explicitly. (@ydah)
Add RSpec/MetadataStyle and RSpec/EmptyMetadata cops.
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)