### PR TITLE
(CAT-2218): Add 'forms' to valid authentication schemas and update validation message

### DIFF
--- a/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb
+++ b/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb
@@ -7,7 +7,7 @@ class PuppetX::PuppetLabs::IIS::Property::AuthenticationInfo < Puppet::Property
         authentication. This type does not ensure a given feature is installed
         before attempting to configure it.'
   valid_schemas = ['anonymous', 'basic', 'clientCertificateMapping',
-                   'digest', 'iisClientCertificateMapping', 'windows']
+                   'digest', 'iisClientCertificateMapping', 'windows', 'forms']
   def insync?(is)
     should.reject { |k, v|
       is[k] == v
@@ -16,7 +16,7 @@ class PuppetX::PuppetLabs::IIS::Property::AuthenticationInfo < Puppet::Property
   validate do |value|
     raise "#{name} should be a Hash" unless value.is_a? ::Hash
     unless (value.keys & valid_schemas) == value.keys
-      raise('All schemas must specify any of the following: anonymous, basic, clientCertificateMapping, digest, iisClientCertificateMapping, or windows')
+      raise('All schemas must specify any of the following: anonymous, basic, clientCertificateMapping, digest, iisClientCertificateMapping, windows, or forms')
     end
   end
 end

--- a/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application/webadministration_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'puppet/provider/iis_powershell'
 
 describe 'iis_application provider' do
   subject(:iis_application_provider) do


### PR DESCRIPTION
## Summary
Add 'forms' to valid authentication schemas and update validation message

## Additional Context
Currently the iis_site and iis_application resources in the puppetlabs-iis module (10.0.1) support the following options within "authenticationinfo":
['anonymous', 'basic', 'clientCertificateMapping','digest', 'iisClientCertificateMapping', 'windows']
per https://github.com/puppetlabs/puppetlabs-iis/blob/main/lib/puppet_x/puppetlabs/iis/property/authenticationinfo.rb

I have nodes running Windows Server 2022 that have 'Forms Authentication' listed as an option, and I'd like to leverage the existing mechanism in this module to ensure that auth option is disabled instead of resorting to DSC.

![Screenshot 2025-03-11 at 4 28 39 PM](https://github.com/user-attachments/assets/efb1aa6f-c836-4209-a687-31774798b8df)


## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-iis/issues/396

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)