### PR TITLE
(CAT-2274): Add support for forms authentication in web administration templates

### DIFF
--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -20,7 +20,8 @@ Get-WebSite | % {
     'clientCertificateMapping',
     'digest',
     'iisClientCertificateMapping',
-    'windows'
+    'windows',
+    'forms'
   )
   $authenticationTypes | Foreach-Object -Begin { $info = @{} } -Process {
     $p = Get-WebConfiguration -Filter "system.webserver/security/authentication/$($_)Authentication" -PSPath "IIS:\sites\$($name)"

--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -26,6 +26,7 @@ Get-WebApplication | % {
       clientCertificateMapping    = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/clientCertificateMappingAuthentication").enabled
       iisClientCertificateMapping = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/iisClientCertificateMappingAuthentication").enabled
       windows                     = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/windowsAuthentication").enabled
+      forms                       = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/formsAuthentication").enabled
     }
     enabledprotocols = [string]$_.enabledProtocols
   }


### PR DESCRIPTION
## Summary
Add support for forms authentication in web administration templates

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-iis/pull/398

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)