### PR TITLE
(MODULES-9895) iis_virtual_directory unable to create directories wit…

### DIFF
--- a/spec/support/utilities/iis_site.rb
+++ b/spec/support/utilities/iis_site.rb
@@ -20,3 +20,13 @@ end
 def remove_all_sites
   run_shell(format_powershell_iis_command('Get-Website | Remove-Website'))
 end
+
+def virtual_directory_path_exists?(site_name, path)
+  ps_script = %(
+    $vdir = Get-WebVirtualDirectory -Site "#{site_name}" | Where-Object { $_.Path -eq "#{path}" };
+    if ($vdir) { Write-Output "true" } else { Write-Output "false" }
+  ).strip
+
+  result = run_shell(format_powershell_iis_command(ps_script))
+  result[:stdout].strip.casecmp('true').zero?
+end


### PR DESCRIPTION
## Summary
This PR addresses [MODULES-9895](https://perforce.atlassian.net/browse/MODULES-9895) — an issue where defining `iis_virtual_directory` resources with the same virtual path across multiple sites resulted in incorrect directory structures being created, such as:

### Fix
The logic has been corrected to ensure virtual directories are created under the appropriate site path, without duplicating the site name in the directory structure. This allows the same virtual directory name (e.g., `includes`) to be used across multiple IIS sites without conflict.

### Example
The following now behaves as expected:
```puppet
iis_virtual_directory { "$site1/includes":
  ensure        => present,
  sitename      => $site1,
  physicalpath  => 'G:\inetpub\includes',
}

iis_virtual_directory { "$site2/includes":
  ensure        => present,
  sitename      => $site2,
  physicalpath  => 'G:\inetpub\includes',
}
```

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.