### PR TITLE
(CAT-2303): Enhance FormsAuthentication handling for IIS applications

### DIFF
--- a/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/_getwebsites.ps1.erb
@@ -24,8 +24,15 @@ Get-WebSite | % {
     'forms'
   )
   $authenticationTypes | Foreach-Object -Begin { $info = @{} } -Process {
-    $p = Get-WebConfiguration -Filter "system.webserver/security/authentication/$($_)Authentication" -PSPath "IIS:\sites\$($name)"
-    $info["$($_)"] = $p.enabled
+    if ($_ -eq 'forms') {
+      # Special handling for formsAuthentication
+      $p = Get-WebConfigurationProperty -Filter "system.web/authentication" -Name "mode" -PSPath "IIS:\Sites\$($name)" -ErrorAction SilentlyContinue
+      $info["$($_)"] = if ($p -eq 'Forms') { $true } else { $false }
+    } else {
+      # Handle other authentication types
+      $p = Get-WebConfiguration -Filter "system.webserver/security/authentication/$($_)Authentication" -PSPath "IIS:\sites\$($name)" -ErrorAction SilentlyContinue
+      $info["$($_)"] = $p.enabled
+    }
   }
   $authenticationinfo = New-Object -TypeName PSObject -Property $info
 

--- a/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
+++ b/lib/puppet/provider/templates/webadministration/getapps.ps1.erb
@@ -26,7 +26,7 @@ Get-WebApplication | % {
       clientCertificateMapping    = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/clientCertificateMappingAuthentication").enabled
       iisClientCertificateMapping = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/iisClientCertificateMappingAuthentication").enabled
       windows                     = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/windowsAuthentication").enabled
-      forms                       = [bool](Get-WebConfiguration -Location "${site}/${name}" -Filter "system.webserver/security/authentication/formsAuthentication").enabled
+      forms                       = [string](Get-WebConfigurationProperty -Location "${site}/${name}" -Filter "system.web/authentication" -Name "mode") -eq "Forms"
     }
     enabledprotocols = [string]$_.enabledProtocols
   }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/pwshlib",
-      "version_requirement": ">= 0.4.0 < 2.0.0"
+      "version_requirement": ">= 0.4.0 < 2.1.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/unit/puppet/provider/iis_site/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_site/webadministration_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'puppet/provider/iis_powershell'
 
 describe Puppet::Type.type(:iis_site).provider(:webadministration) do
   subject(:webadministration) { described_class.new }
@@ -55,6 +56,74 @@ describe Puppet::Type.type(:iis_site).provider(:webadministration) do
         }
         expect(webadministration.ssl?).to be false
       end
+    end
+  end
+
+  context 'updating authenticationinfo for IIS_Site' do
+    let(:iis_site_resource) do
+      result = Puppet::Type.type(:iis_site).new(
+        name: 'foo',
+        ensure: :present,
+        physicalpath: 'C:\inetpub\wwwroot\foo',
+        applicationpool: 'MyAppPool',
+        enabledprotocols: 'http,https',
+        authenticationinfo: {
+          'anonymous' => true,
+          'basic' => false,
+          'clientCertificateMapping' => false,
+          'digest' => false,
+          'iisClientCertificateMapping' => false,
+          'windows' => false,
+          'forms' => true
+        },
+      )
+      result.provider = webadministration
+      result
+    end
+    let(:authenticationinfo) do
+      {
+        'anonymous' => true,
+        'basic' => false,
+        'clientCertificateMapping' => false,
+        'digest' => false,
+        'iisClientCertificateMapping' => false,
+        'windows' => false,
+        'forms' => true
+      }
+    end
+
+    before :each do
+      cmd = []
+      cmd << described_class.ps_script_content('_setwebsite', iis_site_resource)
+      cmd << described_class.ps_script_content('trysetitemproperty', iis_site_resource)
+      cmd << described_class.ps_script_content('generalproperties', iis_site_resource)
+      cmd << described_class.ps_script_content('bindingproperty', iis_site_resource)
+      cmd << described_class.ps_script_content('logproperties', iis_site_resource)
+      cmd << described_class.ps_script_content('limitsproperty', iis_site_resource)
+      cmd << described_class.ps_script_content('serviceautostartprovider', iis_site_resource)
+      authenticationinfo.each do |auth, enable|
+        args = []
+        if auth == 'forms' # Forms authentication requires a different command
+          mode_value = enable ? 'Forms' : 'None'
+          args << "-Filter 'system.web/authentication'"
+          args << "-PSPath 'IIS:\\Sites\\foo'"
+          args << "-Name 'mode'"
+          args << "-Value '#{mode_value}'"
+        else
+          args << "-Filter 'system.webserver/security/authentication/#{auth}Authentication'"
+          args << "-PSPath 'IIS:\\'"
+          args << "-Location 'foo'"
+          args << '-Name enabled'
+          args << "-Value #{enable}"
+        end
+        cmd << "Set-WebConfigurationProperty #{args.join(' ')} -ErrorAction Stop\n"
+      end
+      allow(Puppet::Provider::IIS_PowerShell).to receive(:run).and_return(exitcode: 0)
+    end
+
+    it 'updates value' do
+      webadministration.authenticationinfo = authenticationinfo
+      webadministration.update
     end
   end
 end


### PR DESCRIPTION
## Summary
Enhance authentication handling for IIS applications:
- Separate handling for formsAuthentication in webadministration.rb
- Update retrieval of formsAuthentication mode in getapps.ps1.erb
- Ensure consistent property access for authentication types

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)