### PR TITLE
(MODULES-11595) Redact password and fix provider spec for iis_application_pool

### DIFF
--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -382,6 +382,14 @@ Puppet::Type.newtype(:iis_application_pool) do
           files, this uses AppCmd.exe. This encrypts the password automatically
           before it is written to the XML configuration files. This provides
           better password security than storing unencrypted passwords."
+
+    def should_to_s(_value)
+      '[redacted sensitive information]'
+    end
+
+    def is_to_s(_value) # rubocop:disable Naming/PredicateName
+      '[redacted sensitive information]'
+    end
   end
 
   newproperty(:orphan_action_exe, parent: PuppetX::PuppetLabs::IIS::Property::String) do

--- a/spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb
@@ -33,4 +33,28 @@ describe provider_class do
       expect(provider_class.new).to respond_to(method)
     end
   end
+
+  describe '#update' do
+    let(:resource) do
+      Puppet::Type.type(:iis_application_pool).new(
+        name: 'iis_application_pool',
+        password: 'Sup3r$ecret!',
+      )
+    end
+    let(:provider) { described_class.new(resource) }
+
+    it 'passes the password directly in the PowerShell command' do
+      expect(described_class).to receive(:run)
+        .with(a_string_including('processModel.password', 'Sup3r$ecret!'))
+        .and_return({ exitcode: 0, errormessage: '' })
+
+      provider.update
+    end
+
+    it 'redacts password in Puppet logs' do
+      prop = resource.property(:password)
+      expect(prop.should_to_s('Sup3r$ecret!')).to eq('[redacted sensitive information]')
+      expect(prop.is_to_s('Sup3r$ecret!')).to eq('[redacted sensitive information]')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Previously, the IIS application pool provider attempted to pass the password via environment variables, which caused unexpected test failures and made logging potentially unsafe. This commit updates the `password` property to use `should_to_s` and `is_to_s` methods that redact sensitive values in logs. In addition, the provider spec is updated to correctly stub `run` and return a result hash, preventing `NoMethodError` during testing.

This ensures sensitive data is not leaked in Puppet logs and stabilizes the unit tests for the `update` method.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)