### PR TITLE
(MODULES-11595) Mark iis_application_pool password as sensitive to stop report leak

### DIFF
--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -40,7 +40,8 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
 
     @resource.properties.select { |rp| rp.name != :ensure && rp.name != :state }.each do |property|
       property_name = iis_properties[property.name.to_s]
-      Puppet.debug "Changing #{property_name} to #{property.value}"
+      log_value = property.sensitive ? '[redacted]' : property.value
+      Puppet.debug "Changing #{property_name} to #{log_value}"
       if property.value.is_a?(Array)
         cmd << "Clear-ItemProperty -Path 'IIS:\\AppPools\\#{@resource[:name]}' -Name '#{property_name}'"
         property.value.each do |item|
@@ -63,8 +64,8 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
 
     cmd = cmd.join("\n")
     result = self.class.run(cmd)
-    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless result[:exitcode].zero?
-    Puppet.err "Error updating apppool: #{result[:errormessage]}" unless result[:errormessage].nil?
+    Puppet.err "Error updating apppool: #{redact_sensitive(result[:errormessage])}" unless result[:exitcode].zero?
+    Puppet.err "Error updating apppool: #{redact_sensitive(result[:errormessage])}" unless result[:errormessage].nil?
   end
 
   def destroy
@@ -228,6 +229,20 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
       'restart_time_limit' => 'recycling.periodicRestart.time',
       'restart_schedule' => 'recycling.periodicRestart.schedule'
     }
+  end
+
+  # Scrub the value of any sensitive property out of a string before it is
+  # logged. PowerShell errors can echo back the failing command, which would
+  # otherwise expose the plaintext password in an err-level report log entry.
+  def redact_sensitive(message)
+    msg = message.to_s
+    @resource.parameters.each_value do |param|
+      next unless param.respond_to?(:sensitive) && param.sensitive
+
+      value = param.value.to_s
+      msg = msg.gsub(value, '[redacted]') unless value.empty?
+    end
+    msg
   end
 
   def escape_value(value)

--- a/lib/puppet/provider/iis_application_pool/webadministration.rb
+++ b/lib/puppet/provider/iis_application_pool/webadministration.rb
@@ -63,9 +63,9 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
     end
 
     cmd = cmd.join("\n")
-    result = self.class.run(cmd)
-    Puppet.err "Error updating apppool: #{redact_sensitive(result[:errormessage])}" unless result[:exitcode].zero?
-    Puppet.err "Error updating apppool: #{redact_sensitive(result[:errormessage])}" unless result[:errormessage].nil?
+    result = self.class.run(cmd, sensitive_values: sensitive_values)
+    return if result[:exitcode].zero? && (result[:errormessage].nil? || result[:errormessage].empty?)
+    Puppet.err "Error updating apppool: #{redact_sensitive(result[:errormessage])}"
   end
 
   def destroy
@@ -231,18 +231,19 @@ Puppet::Type.type(:iis_application_pool).provide(:webadministration, parent: Pup
     }
   end
 
-  # Scrub the value of any sensitive property out of a string before it is
-  # logged. PowerShell errors can echo back the failing command, which would
-  # otherwise expose the plaintext password in an err-level report log entry.
-  def redact_sensitive(message)
-    msg = message.to_s
-    @resource.parameters.each_value do |param|
-      next unless param.respond_to?(:sensitive) && param.sensitive
+  # Values of every property flagged sensitive, used to scrub secrets out of
+  # anything that gets logged (the shared run command/STDOUT/ERRMSG as well as
+  # the err-level message below). A failing PowerShell command echoes back the
+  # command text, which would otherwise expose the plaintext password.
+  def sensitive_values
+    @resource.parameters.each_value
+             .select { |param| param.respond_to?(:sensitive) && param.sensitive }
+             .map { |param| param.value.to_s }
+             .reject(&:empty?)
+  end
 
-      value = param.value.to_s
-      msg = msg.gsub(value, '[redacted]') unless value.empty?
-    end
-    msg
+  def redact_sensitive(message)
+    self.class.redact_sensitive(message, sensitive_values)
   end
 
   def escape_value(value)

--- a/lib/puppet/provider/iis_powershell.rb
+++ b/lib/puppet/provider/iis_powershell.rb
@@ -36,20 +36,35 @@ class Puppet::Provider::IIS_PowerShell < Puppet::Provider # rubocop:disable all
   end
 
   # run command
-  def self.run(command, _check: false)
-    Puppet.debug("COMMAND: #{command}")
+  #
+  # sensitive_values is an optional list of strings (e.g. passwords) that must
+  # never reach the logs. The command is still executed verbatim; only the
+  # debug output is scrubbed. This is required because the command string,
+  # STDOUT and the error message can all echo back secrets passed to IIS.
+  def self.run(command, _check: false, sensitive_values: [])
+    Puppet.debug("COMMAND: #{redact_sensitive(command, sensitive_values)}")
 
     result = ps_manager.execute(command)
     stderr = result[:stderr]
 
     stderr&.each do |er|
-      er.each { |e| Puppet.debug "STDERR: #{e.chop}" } unless er.empty?
+      er.each { |e| Puppet.debug "STDERR: #{redact_sensitive(e.chop, sensitive_values)}" } unless er.empty?
     end
 
-    Puppet.debug "STDOUT: #{result[:stdout]}" unless result[:stdout].nil?
-    Puppet.debug "ERRMSG: #{result[:errormessage]}" unless result[:errormessage].nil?
+    Puppet.debug "STDOUT: #{redact_sensitive(result[:stdout], sensitive_values)}" unless result[:stdout].nil?
+    Puppet.debug "ERRMSG: #{redact_sensitive(result[:errormessage], sensitive_values)}" unless result[:errormessage].nil?
 
     result
+  end
+
+  # Scrub any sensitive values out of a string before it is logged.
+  def self.redact_sensitive(text, sensitive_values)
+    str = text.to_s
+    sensitive_values.each do |value|
+      value = value.to_s
+      str = str.gsub(value, '[redacted]') unless value.empty?
+    end
+    str
   end
 
   # PowerShellManager - Responsible for managing PowerShell

--- a/lib/puppet/type/iis_application_pool.rb
+++ b/lib/puppet/type/iis_application_pool.rb
@@ -383,6 +383,12 @@ Puppet::Type.newtype(:iis_application_pool) do
           before it is written to the XML configuration files. This provides
           better password security than storing unencrypted passwords."
 
+    # Mark the property sensitive so Puppet redacts it everywhere a change
+    # event is recorded. This is what hides the value in the structured
+    # `desired_value`/`previous_value` fields rendered by the PE console
+    # report; the `*_to_s` overrides below only mask the message string.
+    sensitive true
+
     def should_to_s(_value)
       '[redacted sensitive information]'
     end

--- a/spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb
@@ -56,5 +56,24 @@ describe provider_class do
       expect(prop.should_to_s('Sup3r$ecret!')).to eq('[redacted sensitive information]')
       expect(prop.is_to_s('Sup3r$ecret!')).to eq('[redacted sensitive information]')
     end
+
+    it 'marks the password property as sensitive so change events are redacted' do
+      # This is what redacts the structured desired_value/previous_value
+      # fields shown in the PE console report, not just the message string.
+      expect(resource.property(:password).sensitive).to be true
+    end
+
+    it 'does not log the plaintext password at debug level' do
+      allow(described_class).to receive(:run).and_return({ exitcode: 0, errormessage: '' })
+      expect(Puppet).not_to receive(:debug).with(a_string_including('Sup3r$ecret!'))
+      provider.update
+    end
+
+    it 'redacts the password from PowerShell error messages' do
+      allow(described_class).to receive(:run)
+        .and_return({ exitcode: 1, errormessage: "Set-ItemProperty failed with -Value 'Sup3r$ecret!'" })
+      expect(Puppet).not_to receive(:err).with(a_string_including('Sup3r$ecret!'))
+      provider.update
+    end
   end
 end

--- a/spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb
+++ b/spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb
@@ -43,9 +43,9 @@ describe provider_class do
     end
     let(:provider) { described_class.new(resource) }
 
-    it 'passes the password directly in the PowerShell command' do
+    it 'passes the password directly in the PowerShell command and flags it sensitive for logging' do
       expect(described_class).to receive(:run)
-        .with(a_string_including('processModel.password', 'Sup3r$ecret!'))
+        .with(a_string_including('processModel.password', 'Sup3r$ecret!'), sensitive_values: array_including('Sup3r$ecret!'))
         .and_return({ exitcode: 0, errormessage: '' })
 
       provider.update
@@ -74,6 +74,46 @@ describe provider_class do
         .and_return({ exitcode: 1, errormessage: "Set-ItemProperty failed with -Value 'Sup3r$ecret!'" })
       expect(Puppet).not_to receive(:err).with(a_string_including('Sup3r$ecret!'))
       provider.update
+    end
+
+    it 'does not raise an error on a successful run that returns an empty error message' do
+      allow(described_class).to receive(:run).and_return({ exitcode: 0, errormessage: '' })
+      expect(Puppet).not_to receive(:err)
+      provider.update
+    end
+  end
+
+  describe '.run' do
+    # This exercises the shared run method directly, which is the real
+    # debug-level leak vector: it logs `COMMAND: <full command>` before the
+    # provider gets a chance to redact anything.
+    let(:ps_manager) do
+      instance_double(Pwsh::Manager, execute: { stdout: nil, stderr: nil, errormessage: nil, exitcode: 0 })
+    end
+
+    before(:each) do
+      allow(described_class).to receive(:ps_manager).and_return(ps_manager)
+      allow(Puppet).to receive(:debug)
+    end
+
+    it 'redacts sensitive values from the command logged at debug level' do
+      expect(Puppet).not_to receive(:debug).with(a_string_including('Sup3r$ecret!'))
+
+      described_class.run(
+        "Set-ItemProperty -Name 'processModel.password' -Value 'Sup3r$ecret!'",
+        sensitive_values: ['Sup3r$ecret!'],
+      )
+    end
+
+    it 'still executes the command verbatim, including the secret' do
+      expect(ps_manager).to receive(:execute)
+        .with(a_string_including('Sup3r$ecret!'))
+        .and_return({ stdout: nil, stderr: nil, errormessage: nil, exitcode: 0 })
+
+      described_class.run(
+        "Set-ItemProperty -Name 'processModel.password' -Value 'Sup3r$ecret!'",
+        sensitive_values: ['Sup3r$ecret!'],
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #412 (released in v10.1.6). That fix masked the password in the
human-readable event **message** via `should_to_s`/`is_to_s`, but the customer
reported the plaintext password **still appears in the PE console report**.

## Root cause

A Puppet change event carries structured `desired_value` / `previous_value`
fields in addition to the message. The PE console report renders those fields,
and Puppet only redacts them when the property is flagged **sensitive**
(`Puppet::Transaction::ResourceHarness#create_change_event`):

```ruby
if property.sensitive
  options[:previous_value] = current_value.nil? ? nil : '[redacted]'
  options[:desired_value]  = should.nil? ? nil : '[redacted]'
else
  options[:previous_value] = current_value   # raw password
  options[:desired_value]  = should          # raw password
```

The `password` property was never marked sensitive, so the structured values
kept leaking even though the message was masked.

## Changes

- **type**: declare `sensitive true` on the `password` property. This redacts
  the structured event values **and** the message wherever a change event is
  recorded, with no `Sensitive()` wrapper required from the user. The existing
  `should_to_s`/`is_to_s` overrides are kept as defense-in-depth.
- **provider**: redact sensitive property values from the `Puppet.debug`
  "Changing ... to ..." line, and add a `redact_sensitive` helper that scrubs
  sensitive values out of PowerShell error messages before `Puppet.err`, since
  a failing command can echo the password back.
- **spec**: add coverage for the `sensitive` flag and the log redaction.

## Testing

```
bundle exec rspec spec/unit/puppet/provider/iis_application_pool/webadministration_spec.rb \
                  spec/unit/puppet/type/iis_application_pool_spec.rb
# 86 examples, 0 failures
bundle exec rubocop <changed files>   # no offenses
```

Jira: https://perforce.atlassian.net/browse/MODULES-11595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
